### PR TITLE
feat: implement public page control and shared layout components

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,28 @@
-<router-outlet></router-outlet>
+<div
+  [ngClass]="{
+    'dark-theme': themeService.isDark(),
+    'card-borderd-theme': themeService.isCardBorder(),
+    'card-border-radius': themeService.isCardBorderRadius(),
+    'rtl-enabled': themeService.isRTLEnabled()
+  }"
+>
+
+  <!-- Sidebar -->
+  <app-sidebar *ngIf="!isLoginPage()"></app-sidebar>
+
+  <!-- Main Content -->
+  <div
+    class="main-content transition d-flex flex-column"
+    [ngClass]="{ 'active': isSidebarToggled }"
+    [class.right-sidebar]="themeService.isRightSidebar()"
+    [class.hide-sidebar]="themeService.isHideSidebar()"
+  >
+    <app-header *ngIf="!isLoginPage()"></app-header>
+
+    <router-outlet></router-outlet>
+
+    <div class="flex-grow-1"></div>
+
+    <app-footer *ngIf="!isLoginPage()"></app-footer>
+  </div>
+</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,275 @@
+// Main Content
+.main-content {
+    overflow: hidden;
+    min-height: 100vh;
+    padding: {
+        top: 118px;
+        left: 282px;
+        right: 25px;
+    };
+    &.active, &.hide-sidebar {
+        padding-left: 85px;
+    }
+    &.right-sidebar {
+        padding: {
+            left: 25px;
+            right: 282px;
+        };
+        &.active, &.hide-sidebar {
+            padding-right: 85px;
+        }
+    }
+}
+
+// Blank Page
+.blank-page {
+    app-sidebar, app-footer, app-header {
+        display: none !important;
+    }
+    .main-content {
+        padding: 0 !important;
+    }
+}
+
+// RTL
+.rtl-enabled {
+    .main-content {
+        padding: {
+            right: 282px;
+            left: 25px;
+        };
+        &.active, &.hide-sidebar {
+            padding: {
+                left: 25px;
+                right: 85px;
+            };
+        }
+        &.right-sidebar {
+            padding: {
+                right: 25px;
+                left: 282px;
+            };
+            &.active, &.hide-sidebar {
+                padding-left: 85px;
+            }
+        }
+    }
+}
+
+/* Max width 767px */
+@media only screen and (max-width : 767px) {
+
+    // Main Content
+    .main-content {
+        padding: {
+            top: 151px;
+            left: 15px;
+            right: 15px;
+        };
+        &.active, &.hide-sidebar {
+            padding-left: 15px;
+        }
+        &.right-sidebar {
+            padding: {
+                left: 15px;
+                right: 15px;
+            };
+            &.active, &.hide-sidebar {
+                padding-right: 15px;
+            }
+        }
+    }
+
+    // RTL
+    .rtl-enabled {
+        .main-content {
+            padding: {
+                right: 15px;
+                left: 15px;
+            };
+            &.active, &.hide-sidebar {
+                padding: {
+                    left: 15px;
+                    right: 15px;
+                };
+            }
+            &.right-sidebar {
+                padding: {
+                    right: 15px;
+                    left: 15px;
+                };
+                &.active, &.hide-sidebar {
+                    padding: {
+                        left: 15px;
+                        right: 15px;
+                    };
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 576px to Max width 767px */
+@media only screen and (min-width : 576px) and (max-width : 767px) {
+
+    // Main Content
+    .main-content {
+        padding-top: 156px;
+    }
+
+}
+
+/* Min width 768px to Max width 991px */
+@media only screen and (min-width : 768px) and (max-width : 991px) {
+
+    // Main Content
+    .main-content {
+        padding: {
+            left: 25px;
+            right: 25px;
+        };
+        &.active, &.hide-sidebar {
+            padding-left: 25px;
+        }
+        &.right-sidebar {
+            padding-right: 25px;
+
+            &.active, &.hide-sidebar {
+                padding-right: 25px;
+            }
+        }
+    }
+
+    // RTL
+    .rtl-enabled {
+        .main-content {
+            padding: {
+                right: 25px;
+                left: 25px;
+            };
+            &.active, &.hide-sidebar {
+                padding: {
+                    left: 25px;
+                    right: 25px;
+                };
+            }
+            &.right-sidebar {
+                padding: {
+                    right: 25px;
+                    left: 25px;
+                };
+                &.active, &.hide-sidebar {
+                    padding: {
+                        left: 25px;
+                        right: 25px;
+                    };
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 992px to Max width 1199px */
+@media only screen and (min-width : 992px) and (max-width : 1199px) {
+
+    // Main Content
+    .main-content {
+        padding: {
+            left: 25px;
+            right: 25px;
+        };
+        &.active, &.hide-sidebar {
+            padding-left: 25px;
+        }
+        &.right-sidebar {
+            padding-right: 25px;
+
+            &.active, &.hide-sidebar {
+                padding-right: 25px;
+            }
+        }
+    }
+
+    // RTL
+    .rtl-enabled {
+        .main-content {
+            padding: {
+                right: 25px;
+                left: 25px;
+            };
+            &.active, &.hide-sidebar {
+                padding: {
+                    left: 25px;
+                    right: 25px;
+                };
+            }
+            &.right-sidebar {
+                padding: {
+                    right: 25px;
+                    left: 25px;
+                };
+                &.active, &.hide-sidebar {
+                    padding: {
+                        left: 25px;
+                        right: 25px;
+                    };
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 1200px to Max width 1399px */
+@media only screen and (min-width: 1200px) and (max-width: 1399px) {
+
+    // Main Content
+    .main-content {
+        padding-left: 262px;
+
+        &.active, &.hide-sidebar {
+            padding-left: 85px;
+        }
+        &.right-sidebar {
+            padding-right: 262px;
+
+            &.active, &.hide-sidebar {
+                padding-right: 85px;
+            }
+        }
+    }
+
+    // RTL
+    .rtl-enabled {
+        .main-content {
+            padding: {
+                right: 262px;
+                left: 25px;
+            };
+            &.active, &.hide-sidebar {
+                padding: {
+                    left: 25px;
+                    right: 85px;
+                };
+            }
+            &.right-sidebar {
+                padding: {
+                    right: 25px;
+                    left: 262px;
+                };
+                &.active, &.hide-sidebar {
+                    padding: {
+                        left: 85px;
+                        right: 25px;
+                    };
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 1600px */
+@media only screen and (min-width: 1600px) {}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,126 @@
+import {SidebarComponent} from "./shared/components/sidebar/sidebar.component";
+
+declare let $: any;
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { filter } from 'rxjs/operators';
+
+import {isPlatformBrowser} from "@angular/common";
+import {PLATFORM_ID, Inject } from "@angular/core";
+
+import { CommonModule, Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
+import { RouterOutlet, Router, NavigationCancel, NavigationEnd, RouterLink } from '@angular/router';
+import {HeaderComponent} from "./shared/components/header/header.component";
+import {FooterComponent} from "./shared/components/footer/footer.component";
+import {ToggleService} from "./shared/components/sidebar/toggle.service";
+import {CustomizerSettingsService} from "./shared/services/customizer-settings/customizer-settings.service";
+import {CustomizerSettingsComponent} from "./shared/components/customizer-settings/customizer-settings.component";
+
 
 @Component({
-  selector: 'app-root',
-  standalone: true,
-  imports: [RouterOutlet],
-  templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+    selector: 'app-root',
+    standalone: true,
+    imports: [CommonModule, RouterOutlet, SidebarComponent, HeaderComponent, FooterComponent, RouterLink, CustomizerSettingsComponent],
+    templateUrl: './app.component.html',
+    styleUrl: './app.component.scss',
+    providers: [
+        Location, {
+            provide: LocationStrategy,
+            useClass: PathLocationStrategy
+        }
+    ]
 })
+
 export class AppComponent {
-  title = 'LlantaTech - RutaKids';
+    isBrowser: boolean;
+
+    title = 'LlantaTech - RutaKids';
+    routerSubscription: any;
+    location: any;
+
+    // isSidebarToggled
+    isSidebarToggled = false;
+
+    // isToggled
+    isToggled = false;
+
+    constructor(
+        public router: Router,
+        private toggleService: ToggleService,
+        public themeService: CustomizerSettingsService,
+        @Inject(PLATFORM_ID) platformId: Object
+    ) {
+        this.isBrowser = isPlatformBrowser(platformId);
+
+        this.toggleService.isSidebarToggled$.subscribe(isSidebarToggled => {
+            this.isSidebarToggled = isSidebarToggled;
+        });
+        this.themeService.isToggled$.subscribe(isToggled => {
+            this.isToggled = isToggled;
+        });
+    }
+
+    isLoginPage() {
+        return this.router.url.startsWith('/authentication');
+    }
+
+    // ngOnInit
+    ngOnInit(){
+        this.recallJsFuntions();
+    }
+
+    // recallJsFuntions
+    recallJsFuntions() {
+        this.routerSubscription = this.router.events
+        .pipe(filter(event => event instanceof NavigationEnd || event instanceof NavigationCancel))
+        .subscribe(event => {
+            this.location = this.router.url;
+
+            if (!(event instanceof NavigationEnd)) return;
+
+            if(this.isBrowser) {
+              window.scrollTo(0, 0);
+            }
+        });
+    }
+
+    // Dark Mode
+    toggleTheme() {
+        this.themeService.toggleTheme();
+    }
+
+    // Sidebar Dark
+    toggleSidebarTheme() {
+        this.themeService.toggleSidebarTheme();
+    }
+
+    // Right Sidebar
+    toggleRightSidebarTheme() {
+        this.themeService.toggleRightSidebarTheme();
+    }
+
+    // Hide Sidebar
+    toggleHideSidebarTheme() {
+        this.themeService.toggleHideSidebarTheme();
+    }
+
+    // Header Dark Mode
+    toggleHeaderTheme() {
+        this.themeService.toggleHeaderTheme();
+    }
+
+    // Card Border
+    toggleCardBorderTheme() {
+        this.themeService.toggleCardBorderTheme();
+    }
+
+    // Card Border Radius
+    toggleCardBorderRadiusTheme() {
+        this.themeService.toggleCardBorderRadiusTheme();
+    }
+
+    // RTL Mode
+    toggleRTLEnabledTheme() {
+        this.themeService.toggleRTLEnabledTheme();
+    }
+
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,7 +4,8 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import {provideAnimations} from "@angular/platform-browser/animations";
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideClientHydration(), provideAnimationsAsync()]
+  providers: [provideRouter(routes), provideClientHydration(), provideAnimations()]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,6 +7,8 @@ import {ResetPasswordComponent} from "./iam/pages/authentication/reset-password/
 import {SignInComponent} from "./iam/pages/authentication/sign-in/sign-in.component";
 import {SignUpComponent} from "./iam/pages/authentication/sign-up/sign-up.component";
 import {ForgotPasswordComponent} from "./iam/pages/authentication/forgot-password/forgot-password.component";
+import {NotFoundComponent} from "./public/pages/not-found/not-found.component";
+import {InternalErrorComponent} from "./public/pages/internal-error/internal-error.component";
 
 export const routes: Routes = [
   {
@@ -25,5 +27,9 @@ export const routes: Routes = [
       {path: 'confirm-email', component: ConfirmEmailComponent},
       {path: 'logout', component: LogoutComponent},
     ]
-  }
+  },
+  { path: 'internal-error', component: InternalErrorComponent },
+
+
+  { path: '**', component: NotFoundComponent }
 ];

--- a/src/app/public/pages/internal-error/internal-error.component.html
+++ b/src/app/public/pages/internal-error/internal-error.component.html
@@ -1,0 +1,14 @@
+<mat-card class="daxa-card error-card mb-25 pt-0 border-radius bg-white border-none d-block text-center">
+    <mat-card-content>
+        <img src="assets/images/internal-error.png" alt="internal-error-image">
+        <h3>
+            Looks like we have an internal error, please try again later.
+        </h3>
+        <p>
+            But no worries! Our team is looking ever where while you wait safely.
+        </p>
+        <a mat-button routerLink="/">
+            Back to Home
+        </a>
+    </mat-card-content>
+</mat-card>

--- a/src/app/public/pages/internal-error/internal-error.component.scss
+++ b/src/app/public/pages/internal-error/internal-error.component.scss
@@ -1,0 +1,85 @@
+.mat-mdc-card {
+    &.daxa-card {
+        &.error-card {
+            padding-bottom: 100px;
+
+            .mat-mdc-card-content {
+                h3 {
+                    margin: {
+                        top: 35px;
+                        bottom: 10px;
+                    };
+                }
+                .mat-mdc-button {
+                    border: 0;
+                    height: auto;
+                    min-width: auto;
+                    min-height: auto;
+                    margin-top: 10px;
+                    padding: 13px 40px;
+                    font-weight: normal;
+                    color: var(--whiteColor);
+                    background-color: var(--daxaColor);
+                }
+            }
+        }
+    }
+}
+
+/* Max width 767px */
+@media only screen and (max-width : 767px) {
+
+    .mat-mdc-card {
+        &.daxa-card {
+            &.error-card {
+                padding-bottom: 40px;
+
+                .mat-mdc-card-content {
+                    h3 {
+                        margin-top: 25px;
+                    }
+                    .mat-mdc-button {
+                        padding: 13px 30px;
+                        margin-top: 5px;
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 576px to Max width 767px */
+@media only screen and (min-width : 576px) and (max-width : 767px) {}
+
+/* Min width 768px to Max width 991px */
+@media only screen and (min-width : 768px) and (max-width : 991px) {
+
+    .mat-mdc-card {
+        &.daxa-card {
+            &.error-card {
+                padding-bottom: 70px;
+            }
+        }
+    }
+
+}
+
+/* Min width 992px to Max width 1199px */
+@media only screen and (min-width : 992px) and (max-width : 1199px) {
+
+    .mat-mdc-card {
+        &.daxa-card {
+            &.error-card {
+                padding-bottom: 90px;
+            }
+        }
+    }
+
+}
+
+/* Min width 1200px to Max width 1399px */
+@media only screen and (min-width: 1200px) and (max-width: 1399px) {}
+
+/* Min width 1600px */
+@media only screen and (min-width: 1600px) {}

--- a/src/app/public/pages/internal-error/internal-error.component.ts
+++ b/src/app/public/pages/internal-error/internal-error.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { RouterLink } from '@angular/router';
+
+@Component({
+    selector: 'app-internal-error',
+    standalone: true,
+    imports: [RouterLink, MatCardModule, MatButtonModule],
+    templateUrl: './internal-error.component.html',
+    styleUrl: './internal-error.component.scss'
+})
+export class InternalErrorComponent {}

--- a/src/app/public/pages/not-found/not-found.component.html
+++ b/src/app/public/pages/not-found/not-found.component.html
@@ -1,0 +1,14 @@
+<mat-card class="daxa-card error-card mb-25 pt-0 border-radius bg-white border-none d-block text-center">
+    <mat-card-content>
+        <img src="assets/images/error.png" alt="error-image">
+        <h3>
+            OOPS! 404 Page Not Found!
+        </h3>
+        <p>
+            But no worries! Our team is looking ever where while you wait safely.
+        </p>
+        <a mat-button routerLink="/">
+            Back to Home
+        </a>
+    </mat-card-content>
+</mat-card>

--- a/src/app/public/pages/not-found/not-found.component.scss
+++ b/src/app/public/pages/not-found/not-found.component.scss
@@ -1,0 +1,85 @@
+.mat-mdc-card {
+    &.daxa-card {
+        &.error-card {
+            padding-bottom: 100px;
+
+            .mat-mdc-card-content {
+                h3 {
+                    margin: {
+                        top: 35px;
+                        bottom: 10px;
+                    };
+                }
+                .mat-mdc-button {
+                    border: 0;
+                    height: auto;
+                    min-width: auto;
+                    min-height: auto;
+                    margin-top: 10px;
+                    padding: 13px 40px;
+                    font-weight: normal;
+                    color: var(--whiteColor);
+                    background-color: var(--daxaColor);
+                }
+            }
+        }
+    }
+}
+
+/* Max width 767px */
+@media only screen and (max-width : 767px) {
+
+    .mat-mdc-card {
+        &.daxa-card {
+            &.error-card {
+                padding-bottom: 40px;
+
+                .mat-mdc-card-content {
+                    h3 {
+                        margin-top: 25px;
+                    }
+                    .mat-mdc-button {
+                        padding: 13px 30px;
+                        margin-top: 5px;
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 576px to Max width 767px */
+@media only screen and (min-width : 576px) and (max-width : 767px) {}
+
+/* Min width 768px to Max width 991px */
+@media only screen and (min-width : 768px) and (max-width : 991px) {
+
+    .mat-mdc-card {
+        &.daxa-card {
+            &.error-card {
+                padding-bottom: 70px;
+            }
+        }
+    }
+
+}
+
+/* Min width 992px to Max width 1199px */
+@media only screen and (min-width : 992px) and (max-width : 1199px) {
+
+    .mat-mdc-card {
+        &.daxa-card {
+            &.error-card {
+                padding-bottom: 90px;
+            }
+        }
+    }
+
+}
+
+/* Min width 1200px to Max width 1399px */
+@media only screen and (min-width: 1200px) and (max-width: 1399px) {}
+
+/* Min width 1600px */
+@media only screen and (min-width: 1600px) {}

--- a/src/app/public/pages/not-found/not-found.component.ts
+++ b/src/app/public/pages/not-found/not-found.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { RouterLink } from '@angular/router';
+
+@Component({
+    selector: 'app-not-found',
+    standalone: true,
+    imports: [RouterLink, MatCardModule, MatButtonModule],
+    templateUrl: './not-found.component.html',
+    styleUrl: './not-found.component.scss'
+})
+export class NotFoundComponent {}

--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -1,0 +1,9 @@
+<footer
+    class="footer-area text-center bg-white border-top-radius"
+    [class.card-borderd-theme]="themeService.isCardBorder()"
+    [class.component-dark-theme]="themeService.isDark()"
+>
+    <p>
+        © <span class="text-black fw-medium">Daxa</span> is Proudly Owned by <a href="https://hibootstrap.com/" target="_blank">HiBootstrap</a>
+    </p>
+</footer>

--- a/src/app/shared/components/footer/footer.component.scss
+++ b/src/app/shared/components/footer/footer.component.scss
@@ -1,0 +1,44 @@
+.footer-area {
+    padding: 18px 25px;
+
+    a {
+        color: var(--daxaColor);
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    &.card-borderd-theme {
+        box-shadow: var(--borderBoxShadow) !important;
+    }
+}
+
+/* Max width 767px */
+@media only screen and (max-width : 767px) {
+
+    .footer-area {
+        padding: 15px;
+    }
+
+}
+
+/* Min width 576px to Max width 767px */
+@media only screen and (min-width : 576px) and (max-width : 767px) {}
+
+/* Min width 768px to Max width 991px */
+@media only screen and (min-width : 768px) and (max-width : 991px) {
+
+    .footer-area {
+        padding: 17px 20px;
+    }
+
+}
+
+/* Min width 992px to Max width 1199px */
+@media only screen and (min-width : 992px) and (max-width : 1199px) {}
+
+/* Min width 1200px to Max width 1399px */
+@media only screen and (min-width: 1200px) and (max-width: 1399px) {}
+
+/* Min width 1600px */
+@media only screen and (min-width: 1600px) {}

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -1,20 +1,15 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { NgClass } from '@angular/common';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { NgScrollbarModule } from 'ngx-scrollbar';
 import {CustomizerSettingsService} from "../../services/customizer-settings/customizer-settings.service";
 
 @Component({
-    selector: 'app-customizer-settings',
+    selector: 'app-footer',
     standalone: true,
-    imports: [RouterLink, NgClass, MatDividerModule, MatIconModule, MatButtonModule, NgScrollbarModule],
-    templateUrl: './customizer-settings.component.html',
-    styleUrl: './customizer-settings.component.scss'
+    imports: [RouterLink],
+    templateUrl: './footer.component.html',
+    styleUrl: './footer.component.scss'
 })
-export class CustomizerSettingsComponent {
+export class FooterComponent {
 
     // isToggled
     isToggled = false;
@@ -57,19 +52,9 @@ export class CustomizerSettingsComponent {
         this.themeService.toggleCardBorderTheme();
     }
 
-    // Card Border Radius
-    toggleCardBorderRadiusTheme() {
-        this.themeService.toggleCardBorderRadiusTheme();
-    }
-
     // RTL Mode
     toggleRTLEnabledTheme() {
         this.themeService.toggleRTLEnabledTheme();
-    }
-
-    // Settings Button Toggle
-    toggle() {
-        this.themeService.toggle();
     }
 
 }

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,0 +1,288 @@
+<header
+    class="header-area bg-white border-radius transition"
+    [ngClass]="{'active': isSidebarToggled, 'sticky': isSticky}"
+    [class.component-dark-theme]="themeService.isDark()"
+    [class.right-sidebar]="themeService.isRightSidebar()"
+    [class.hide-sidebar]="themeService.isHideSidebar()"
+    [class.dark-header]="themeService.isHeaderDark()"
+    [class.card-borderd-theme]="themeService.isCardBorder()"
+    [class.rtl-enabled]="themeService.isRTLEnabled()"
+>
+    <div class="d-md-flex align-items-center justify-content-between">
+        <div class="header-left-side d-flex align-items-center">
+            <div
+                class="burger-menu cursor-pointer transition d-xl-none"
+                [ngClass]="{'active': isSidebarToggled}"
+                (click)="toggle()"
+            >
+                <span class="top-bar d-block bg-black transition"></span>
+                <span class="middle-bar d-block bg-black transition"></span>
+                <span class="bottom-bar d-block bg-black transition"></span>
+            </div>
+            <form class="search-box position-relative">
+                <i class="material-symbols-outlined">
+                    search
+                </i>
+                <input type="text" class="input-search d-block w-100 border-none outline-0" placeholder="Search here...">
+            </form>
+        </div>
+        <ul class="header-right-side d-flex align-items-center mt-0 mb-0 pl-0 list-unstyled">
+            <li>
+                <button mat-icon-button [matMenuTriggerFor]="languageMenu" class="language-menu-btn">
+                    <i class="material-symbols-outlined">
+                        translate
+                    </i>
+                </button>
+                <mat-menu class="language-menu-dropdown" #languageMenu="matMenu" xPosition="before">
+                    <div
+                        [class.dark-menu]="themeService.isDark() || themeService.isHeaderDark()"
+                    >
+                        <span class="title fw-medium d-block">Choose Language</span>
+                        <ul class="menu-body pl-0 mb-0 mt-0 list-unstyled">
+                            <li>
+                                <button mat-button>
+                                    <img src="assets/images/flags/usa.png" alt="flag">
+                                    English
+                                </button>
+                            </li>
+                            <li>
+                                <button mat-button>
+                                    <img src="assets/images/flags/australia.png" alt="flag">
+                                    Australian
+                                </button>
+                            </li>
+                            <li>
+                                <button mat-button>
+                                    <img src="assets/images/flags/spain.png" alt="flag">
+                                    Spanish
+                                </button>
+                            </li>
+                            <li>
+                                <button mat-button>
+                                    <img src="assets/images/flags/france.png" alt="flag">
+                                    French
+                                </button>
+                            </li>
+                            <li>
+                                <button mat-button>
+                                    <img src="assets/images/flags/germany.png" alt="flag">
+                                    German
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </mat-menu>
+            </li>
+            <li>
+                <button
+                    mat-button
+                    class="dark-swtich-btn"
+                    (click)="toggleTheme()"
+                >
+                    <i class="material-symbols-outlined">
+                        dark_mode
+                    </i>
+                </button>
+            </li>
+            <li>
+                <a routerLink="/calendar" mat-icon-button class="calendar-menu-btn p-0">
+                    <i class="material-symbols-outlined">
+                        calendar_today
+                    </i>
+                </a>
+            </li>
+            <li>
+                <button mat-icon-button [matMenuTriggerFor]="messagesMenu" class="messages-menu-btn p-0">
+                    <i class="material-symbols-outlined">
+                        mail
+                    </i>
+                    <span class="daxa-badge">
+                        5
+                    </span>
+                </button>
+                <mat-menu class="messages-menu-dropdown" #messagesMenu="matMenu" xPosition="before">
+                    <div
+                        [class.dark-menu]="themeService.isDark() || themeService.isHeaderDark()"
+                    >
+                        <div class="title d-flex align-items-center justify-content-between">
+                            <span class="fw-medium">
+                                Messages 
+                                <span class="text-body fw-normal">(05)</span>
+                            </span>
+                            <a routerLink="/chat" class="link-btn text-daxa">
+                                Mark all as read
+                            </a>
+                        </div>
+                        <ul class="menu-body pl-0 mt-0 list-unstyled">
+                            <li class="position-relative">
+                                <img src="assets/images/users/user1.jpg" width="44" height="44" class="rounded-circle position-absolute" alt="user">
+                                <span class="sub-title d-block fw-medium">
+                                    Jacob Liwiski <span class="text-body fw-normal">35 mins ago</span>
+                                </span>
+                                <span class="message d-block text-body">
+                                    Hey Victor! Could you please...
+                                </span>
+                                <a routerLink="/chat" class="d-block link-btn position-absolute"></a>
+                                <span class="unread d-inline-block rounded-circle bg-daxa position-absolute"></span>
+                            </li>
+                            <li class="position-relative">
+                                <img src="assets/images/users/user2.jpg" width="44" height="44" class="rounded-circle position-absolute" alt="user">
+                                <span class="sub-title d-block fw-medium">
+                                    Angela Carter <span class="text-body fw-normal">1 day ago</span>
+                                </span>
+                                <span class="message d-block text-body">
+                                    How are you Angela? Would you please...
+                                </span>
+                                <a routerLink="/chat" class="d-block link-btn position-absolute"></a>
+                            </li>
+                            <li class="position-relative">
+                                <img src="assets/images/users/user3.jpg" width="44" height="44" class="rounded-circle position-absolute" alt="user">
+                                <span class="sub-title d-block fw-medium">
+                                    Brad Traversy  <span class="text-body fw-normal">2 days ago</span>
+                                </span>
+                                <span class="message d-block text-body">
+                                    Hey Brad Traversy! Could you please...
+                                </span>
+                                <a routerLink="/chat" class="d-block link-btn position-absolute"></a>
+                            </li>
+                        </ul>
+                        <div class="menu-footer text-center">
+                            <a routerLink="/chat" class="link-btn text-daxa d-inline-block fw-medium">
+                                View All Messages
+                            </a>
+                        </div>
+                    </div>
+                </mat-menu>
+            </li>
+            <li>
+                <button mat-icon-button [matMenuTriggerFor]="notificationsMenu" class="notifications-menu-btn p-0">
+                    <i class="material-symbols-outlined">
+                        notifications
+                    </i>
+                    <span class="daxa-badge">
+                        3
+                    </span>
+                </button>
+                <mat-menu class="notifications-menu-dropdown" #notificationsMenu="matMenu" xPosition="before">
+                    <div
+                        [class.dark-menu]="themeService.isDark() || themeService.isHeaderDark()"
+                    >
+                        <div class="title d-flex align-items-center justify-content-between">
+                            <span class="fw-medium">
+                                Notifications
+                                <span class="text-body fw-normal">(03)</span>
+                            </span>
+                            <a routerLink="/notifications" class="link-btn text-daxa">
+                                Clear All
+                            </a>
+                        </div>
+                        <ul class="menu-body pl-0 mt-0 list-unstyled">
+                            <li class="position-relative">
+                                <div class="icon rounded-circle position-absolute text-center transition">
+                                    <i class="material-symbols-outlined">
+                                        sms
+                                    </i>
+                                </div>
+                                <span class="sub-title d-block">
+                                    You have requested to <strong class="fw-medium">withdrawal</strong>
+                                </span>
+                                <span class="time d-block text-body">
+                                    2 hrs ago
+                                </span>
+                                <a routerLink="/notifications" class="d-block link-btn position-absolute"></a>
+                                <span class="unread d-inline-block rounded-circle bg-daxa position-absolute"></span>
+                            </li>
+                            <li class="position-relative">
+                                <div class="icon rounded-circle position-absolute text-center transition">
+                                    <i class="material-symbols-outlined">
+                                        person
+                                    </i>
+                                </div>
+                                <span class="sub-title d-block">
+                                    <strong class="fw-medium">A new user</strong> added in Daxa
+                                </span>
+                                <span class="time d-block text-body">
+                                    3 hrs ago
+                                </span>
+                                <a routerLink="/notifications" class="d-block link-btn position-absolute"></a>
+                                <span class="unread d-inline-block rounded-circle bg-daxa position-absolute"></span>
+                            </li>
+                            <li class="position-relative">
+                                <div class="icon rounded-circle position-absolute text-center transition">
+                                    <i class="material-symbols-outlined">
+                                        mark_email_unread
+                                    </i>
+                                </div>
+                                <span class="sub-title d-block">
+                                    You have requested to <strong class="fw-medium">withdrawal</strong>
+                                </span>
+                                <span class="time d-block text-body">
+                                    1 day ago
+                                </span>
+                                <a routerLink="/notifications" class="d-block link-btn position-absolute"></a>
+                            </li>
+                        </ul>
+                        <div class="menu-footer text-center">
+                            <a routerLink="/notifications" class="link-btn text-daxa d-inline-block fw-medium">
+                                See All Notifications
+                            </a>
+                        </div>
+                    </div>
+                </mat-menu>
+            </li>
+            <li>
+                <button mat-button [matMenuTriggerFor]="profileMenu" class="profile-menu-btn">
+                    <img src="assets/images/admin.png" alt="profile-image">
+                    <span class="status d-inline-block rounded-circle position-absolute"></span>
+                </button>
+                <mat-menu class="profile-menu-dropdown" #profileMenu="matMenu" xPosition="before">
+                    <div
+                        [class.dark-menu]="themeService.isDark() || themeService.isHeaderDark()"
+                    >
+                        <div class="menu-header d-flex align-items-center">
+                            <img src="assets/images/admin.png" alt="profile-image">
+                            <div class="title">
+                                <a routerLink="/my-profile" class="d-inline-block fw-medium">
+                                    Mateo Luca
+                                </a>
+                                <span class="designation d-block text-body">
+                                    Admin
+                                </span>
+                            </div>
+                        </div>
+                        <ul class="menu-body pl-0 mb-0 mt-0 list-unstyled">
+                            <li class="position-relative transition fw-medium">
+                                <i class="material-symbols-outlined">
+                                    person
+                                </i>
+                                My Profile
+                                <a routerLink="/my-profile" class="link-btn d-block position-absolute"></a>
+                            </li>
+                            <li class="position-relative transition fw-medium">
+                                <i class="material-symbols-outlined">
+                                    settings
+                                </i>
+                                Settings
+                                <a routerLink="/settings" class="link-btn d-block position-absolute"></a>
+                            </li>
+                            <li class="position-relative transition fw-medium">
+                                <i class="material-symbols-outlined">
+                                    info
+                                </i>
+                                Support
+                                <a routerLink="/settings/connections" class="link-btn d-block position-absolute"></a>
+                            </li>
+                            <li class="position-relative transition fw-medium">
+                                <i class="material-symbols-outlined">
+                                    logout
+                                </i>
+                                Logout
+                                <a routerLink="/authentication/logout" class="link-btn d-block position-absolute"></a>
+                            </li>
+                        </ul>
+                    </div>
+                </mat-menu>
+            </li>
+        </ul>
+    </div>
+</header>

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -1,0 +1,1500 @@
+::ng-deep {
+    .header-area {
+        top: 25px;
+        left: 282px;
+        right: 25px;
+        z-index: 101;
+        height: auto;
+        padding: 12px;
+        position: fixed;
+    
+        .header-left-side {
+            .burger-menu {
+                margin-right: 15px;
+    
+                span {
+                    height: 1px;
+                    width: 25px;
+                    margin: 6px 0;
+                }
+                &.active {
+                    span {
+                        &.top-bar {
+                            transform: rotate(45deg);
+                            transform-origin: 10% 10%;
+                        }
+                        &.middle-bar {
+                            opacity: 0;
+                        }
+                        &.bottom-bar {
+                            transform: rotate(-45deg);
+                            transform-origin: 10% 90%;
+                            margin-top: 5px;
+                        }
+                    }
+                }
+            }
+            .search-box {
+                width: 360px;
+    
+                i {
+                    transform: translateY(-50%);
+                    color: var(--blackColor);
+                    position: absolute;
+                    font-size: 18px;
+                    left: 13px;
+                    top: 50%;
+                }
+                .input-search {
+                    height: 40px;
+                    font-size: 14px;
+                    border-radius: 3px;
+                    background: #f4f6fc;
+                    color: var(--blackColor);
+                    padding: {
+                        left: 40px;
+                        right: 15px;
+                    };
+                    &::placeholder {
+                        font-weight: 300;
+                        color: var(--bodyColor);
+                        transition: var(--transition);
+                    }
+                    &:focus {
+                        &::placeholder {
+                            color: transparent;
+                        }
+                    }
+                }
+            }
+        }
+        .header-right-side {
+            position: relative;
+            top: 2px;
+
+            li {
+                .language-menu-btn {
+                    width: auto;
+                    height: auto;
+                    border-radius: 0;
+                    margin-right: 18px;
+                    padding: 0 20px 0 0;
+
+                    i {
+                        font-size: 18px;
+                        color: var(--blackColor);
+                    }
+                    &::after {
+                        top: 50%;
+                        right: 0;
+                        margin-top: -2px;
+                        content: "\ea4e";
+                        position: absolute;
+                        color: var(--blackColor);
+                        transform: translateY(-50%);
+                        font-family: remixicon !important;
+                    }
+                    &.mat-mdc-icon-button {
+                        .mat-mdc-button-persistent-ripple {
+                            border-radius: 0;
+                        }
+                    }
+                }
+                .dark-swtich-btn {
+                    &.mat-mdc-button {
+                        min-width: auto;
+                        height: auto;
+                        width: auto;
+                        padding: 0;
+            
+                        i {
+                            font-size: 20px;
+                            color: var(--blackColor);
+                        }
+                    }
+                }
+                .calendar-menu-btn {
+                    width: auto;
+                    height: auto;
+                    line-height: 1;
+                    border-radius: 0;
+                    margin: {
+                        left: 22px;
+                        top: -3px;
+                    };
+                    i {
+                        font-size: 19px;
+                        color: var(--blackColor);
+                    }
+                    &.mat-mdc-icon-button {
+                        .mat-mdc-button-persistent-ripple {
+                            border-radius: 0;
+                        }
+                    }
+                }
+                .messages-menu-btn {
+                    width: auto;
+                    height: auto;
+                    border-radius: 0;
+                    margin-left: 23px;
+
+                    i {
+                        font-size: 20px;
+                        margin-right: -7px;
+                        color: var(--blackColor);
+                    }
+                    &.mat-mdc-icon-button {
+                        .mat-mdc-button-persistent-ripple {
+                            border-radius: 0;
+                        }
+                    }
+                    .daxa-badge {
+                        top: -15px;
+                        width: 17px;
+                        height: 17px;
+                        line-height: 17px;
+                        position: relative;
+                        border-radius: 50%;
+                        display: inline-block;
+                        color: var(--whiteColor);
+                        background-color: var(--daxaColor);
+                        font: {
+                            size: 10px;
+                            weight: 500;
+                        };
+                    }
+                }
+                .notifications-menu-btn {
+                    width: auto;
+                    height: auto;
+                    border-radius: 0;
+                    margin-left: 19px;
+
+                    i {
+                        font-size: 20px;
+                        margin-right: -10px;
+                        color: var(--blackColor);
+                    }
+                    &.mat-mdc-icon-button {
+                        .mat-mdc-button-persistent-ripple {
+                            border-radius: 0;
+                        }
+                    }
+                    .daxa-badge {
+                        top: -15px;
+                        width: 17px;
+                        height: 17px;
+                        line-height: 17px;
+                        position: relative;
+                        border-radius: 50%;
+                        display: inline-block;
+                        color: var(--whiteColor);
+                        background-color: var(--dangerColor);
+                        font: {
+                            size: 10px;
+                            weight: 500;
+                        };
+                    }
+                }
+                .profile-menu-btn {
+                    top: -2px;
+                    width: auto;
+                    height: auto;
+                    min-width: auto;
+                    margin-left: 20px;
+                    position: relative;
+                    padding: 0 18px 0 0;
+
+                    img {
+                        width: 40px;
+                        border-radius: 50%;
+                    }
+                    &::after {
+                        top: 50%;
+                        right: -3px;
+                        content: "\ea4e";
+                        position: absolute;
+                        color: var(--blackColor);
+                        transform: translateY(-50%);
+                        font-family: remixicon !important;
+                    }
+                    &.mat-mdc-icon-button {
+                        .mat-mdc-button-persistent-ripple {
+                            border-radius: 0;
+                        }
+                    }
+                    .status {
+                        right: 0;
+                        bottom: 3px;
+                        width: 11px;
+                        height: 11px;
+                        border: 2px solid var(--whiteColor);
+                        background-color: #2ecc71;
+                    }
+                }
+            }
+        }
+        &.sticky {
+            top: 0;
+            box-shadow: 0px 0px 35px 0px rgba(154, 161, 171, 0.15);
+        }
+        &.active, &.hide-sidebar {
+            left: 85px;
+        }
+        &.right-sidebar {
+            left: 25px;
+            right: 282px;
+
+            &.active, &.hide-sidebar {
+                right: 85px;
+            }
+        }
+        &.card-borderd-theme {
+            box-shadow: var(--borderBoxShadow) !important;
+        }
+        &.component-dark-theme, &.dark-header {
+            .header-left-side {
+                .burger-menu {
+                    span {
+                        background: var(--whiteColor) !important;
+                    }
+                }
+                .search-box {
+                    i {
+                        color: var(--whiteColor);
+                    }
+                    .input-search {
+                        background: rgba(255, 255, 255, .07);
+                        color: var(--whiteColor);
+                        
+                        &::placeholder {
+                            color: rgba(255, 255, 255, .50);
+                        }
+                        &:focus {
+                            &::placeholder {
+                                color: transparent;
+                            }
+                        }
+                    }
+                }
+            }
+            .header-right-side {
+                li {
+                    .language-menu-btn {
+                        i {
+                            color: var(--whiteColor);
+                        }
+                        &::after {
+                            color: var(--whiteColor);
+                        }
+                    }
+                    .dark-swtich-btn {
+                        &.mat-mdc-button {
+                            i {
+                                color: var(--whiteColor);
+                            }
+                        }
+                    }
+                    .calendar-menu-btn {
+                        i {
+                            color: var(--whiteColor);
+                        }
+                    }
+                    .messages-menu-btn {
+                        i {
+                            color: var(--whiteColor);
+                        }
+                    }
+                    .notifications-menu-btn {
+                        i {
+                            color: var(--whiteColor);
+                        }
+                    }
+                    .profile-menu-btn {
+                        &::after {
+                            color: var(--whiteColor);
+                        }
+                    }
+                }
+            }
+        }
+        &.dark-header {
+            &.bg-white {
+                background-color: #1b232d !important;
+            }
+        }
+        &.rtl-enabled {
+            left: 25px;
+            right: 282px;
+
+            .header-left-side {
+                .burger-menu {
+                    margin: {
+                        left: 15px;
+                        right: 0;
+                    };
+                }
+                .search-box {
+                    i {
+                        right: 13px;
+                        left: auto;
+                    }
+                    .input-search {
+                        padding: {
+                            right: 40px;
+                            left: 15px;
+                        };
+                    }
+                }
+            }
+            .header-right-side {
+                padding-right: 0;
+                
+                li {
+                    .language-menu-btn {
+                        padding: 0 0 0 20px;
+                        margin: {
+                            right: 0;
+                            left: 18px;
+                        };
+                        &::after {
+                            right: auto;
+                            left: 0;
+                        }
+                    }
+                    .calendar-menu-btn {
+                        margin: {
+                            right: 22px;
+                            left: 0;
+                        };
+                    }
+                    .messages-menu-btn {
+                        margin: {
+                            left: 0;
+                            right: 23px;
+                        };
+                        i {
+                            margin: {
+                                right: 0;
+                                left: -7px;
+                            };
+                        }
+                    }
+                    .notifications-menu-btn {
+                        margin: {
+                            left: 0;
+                            right: 19px;
+                        };
+                        i {
+                            margin: {
+                                left: -10px;
+                                right: 0;
+                            };
+                        }
+                    }
+                    .profile-menu-btn {
+                        padding: 0 0 0 18px;
+                        margin: {
+                            left: 0;
+                            right: 20px;
+                        };
+                        &::after {
+                            right: auto;
+                            left: -3px;
+                        }
+                        .status {
+                            right: auto;
+                            left: 0;
+                        }
+                    }
+                }
+            }
+            &.active, &.hide-sidebar {
+                left: 25px;
+                right: 85px;
+            }
+            &.right-sidebar {
+                right: 25px;
+                left: 282px;
+    
+                &.active, &.hide-sidebar {
+                    left: 85px;
+                }
+            }
+        }
+    }
+    .mat-mdc-menu-panel {
+        &.language-menu-dropdown {
+            width: 220px;
+            height: auto;
+            max-width: 220px;
+            overflow: hidden;
+            margin-top: 10px;
+            padding: 20px 0 0;
+            border-radius: 15px;
+            box-shadow: 0px 4px 34px rgba(101, 96, 240, 0.1);
+
+            .mat-mdc-menu-content {
+                padding: 0;
+            }
+            .title {
+                padding: 0 25px 20px;
+            }
+            .menu-body {
+                li {
+                    border-bottom: 1px dashed #e7e2e2;
+
+                    .mdc-button {
+                        padding: 0;
+                        width: 100%;
+                        height: auto;
+                        display: block;
+                        padding: 14px 25px;
+                        
+                        .mdc-button__label {
+                            display: flex;
+                            align-items: center;
+                            color: var(--blackColor);
+                            font: {
+                                size: 15px;
+                                weight: 500;
+                            };
+                            img {
+                                margin-right: 10px;
+                                width: 30px;
+                            }
+                        }
+                    }
+                    &:first-child {
+                        border-top: 1px dashed #e7e2e2;
+                    }
+                    &:last-child {
+                        border-bottom: 0;
+                    }
+                }
+            }
+            &:has(.dark-menu) {
+                box-shadow: unset !important;
+                background-color: #1b232d !important;
+
+                .title {
+                    color: var(--whiteColor);
+                }
+                .text-body {
+                    color: rgba(255, 255, 255, .50) !important;
+                }
+                .menu-body {
+                    li {
+                        border-color: rgba(255, 255, 255, 0.09);
+    
+                        .mdc-button {
+                            .mdc-button__label {
+                                color: var(--whiteColor);
+                            }
+                            .mat-mdc-button-persistent-ripple {
+                                &::before {
+                                    --mat-text-button-state-layer-color: var(--whiteColor);
+                                }
+                            }
+                        }
+                        &:first-child {
+                            border-color: rgba(255, 255, 255, 0.09);
+                        }
+                    }
+                }
+                a {
+                    color: var(--whiteColor);
+
+                    &:hover {
+                        color: var(--daxaColor);
+                    }
+                }
+            }
+        }
+        &.messages-menu-dropdown {
+            width: 375px;
+            height: auto;
+            padding: 25px 0;
+            max-width: 375px;
+            overflow: hidden;
+            margin-top: 10px;
+            border-radius: 15px;
+            box-shadow: 0px 4px 34px rgba(101, 96, 240, 0.1);
+
+            .title {
+                padding: {
+                    left: 25px;
+                    right: 25px;
+                    bottom: 25px;
+                };
+                .link-btn {
+                    font-size: 15px;
+                }
+            }
+            .menu-body {
+                margin-bottom: 25px;
+
+                li {
+                    border-bottom: 1px dashed #e7e2e2;
+                    padding: 18px 25px 18px 80px;
+
+                    img {
+                        top: 50%;
+                        left: 25px;
+                        transform: translateY(-50%);
+                    }
+                    .sub-title {
+                        margin-bottom: 5px;
+                        
+                        span {
+                            font-size: 14.5px;
+                            margin-left: 5px;
+                        }
+                    }
+                    .message {
+                        font-size: 14.5px;
+                    }
+                    .unread {
+                        top: 50%;
+                        width: 7px;
+                        right: 25px;
+                        height: 7px;
+                        transform: translateY(-50%);
+                    }
+                    .link-btn {
+                        top: 0;
+                        left: 0;
+                        right: 0;
+                        bottom: 0;
+                        z-index: 1;
+                    }
+                    &:first-child {
+                        border-top: 1px dashed #e7e2e2;
+                    }
+                }
+            }
+            .menu-footer {
+                a {
+                    font-size: 15px;
+                    text-decoration: underline;
+                }
+            }
+            .mat-mdc-menu-content {
+                padding: 0;
+            }
+            &:has(.dark-menu) {
+                box-shadow: unset !important;
+                background-color: #1b232d !important;
+
+                .title {
+                    color: var(--whiteColor);
+                }
+                .text-body {
+                    color: rgba(255, 255, 255, .50) !important;
+                }
+                .menu-body {
+                    li {
+                        border-color: rgba(255, 255, 255, 0.09);
+                        color: var(--whiteColor);
+                        
+                        &:first-child {
+                            border-color: rgba(255, 255, 255, 0.09);
+                        }
+                    }
+                }
+                a {
+                    color: var(--whiteColor);
+
+                    &:hover {
+                        color: var(--daxaColor);
+                    }
+                }
+            }
+        }
+        &.notifications-menu-dropdown {
+            width: 375px;
+            height: auto;
+            padding: 25px 0;
+            max-width: 375px;
+            overflow: hidden;
+            margin-top: 10px;
+            border-radius: 15px;
+            box-shadow: 0px 4px 34px rgba(101, 96, 240, 0.1);
+
+            .title {
+                padding: {
+                    left: 25px;
+                    right: 25px;
+                    bottom: 25px;
+                };
+                .link-btn {
+                    font-size: 15px;
+                }
+            }
+            .menu-body {
+                margin-bottom: 25px;
+
+                li {
+                    border-bottom: 1px dashed #e7e2e2;
+                    padding: 18px 25px 18px 80px;
+
+                    .icon {
+                        top: 50%;
+                        left: 25px;
+                        width: 44px;
+                        height: 44px;
+                        background: #f5f5f5;
+                        color: var(--daxaColor);
+                        transform: translateY(-50%);
+
+                        i {
+                            left: 0;
+                            right: 0;
+                            top: 50%;
+                            line-height: 1;
+                            font-size: 21px;
+                            position: absolute;
+                            transform: translateY(-50%);
+                            margin: {
+                                left: auto;
+                                right: auto;
+                            };
+                        }
+                    }
+                    .sub-title {
+                        margin-bottom: 5px;
+                    }
+                    .unread {
+                        top: 50%;
+                        width: 7px;
+                        right: 25px;
+                        height: 7px;
+                        transform: translateY(-50%);
+                    }
+                    .time {
+                        font-size: 14.5px;
+                    }
+                    .link-btn {
+                        top: 0;
+                        left: 0;
+                        right: 0;
+                        bottom: 0;
+                        z-index: 1;
+                    }
+                    &:hover {
+                        .icon {
+                            background-color: var(--daxaColor) !important;
+                            color: var(--whiteColor) !important;
+                        }
+                    }
+                    &:first-child {
+                        border-top: 1px dashed #e7e2e2;
+                    }
+                    &:nth-child(2) {
+                        .icon {
+                            color: #39b2de;
+                        }
+                    }
+                    &:nth-child(3) {
+                        .icon {
+                            color: #06b48a;
+                        }
+                    }
+                }
+            }
+            .menu-footer {
+                a {
+                    font-size: 15px;
+                    text-decoration: underline;
+                }
+            }
+            .mat-mdc-menu-content {
+                padding: 0;
+            }
+            &:has(.dark-menu) {
+                box-shadow: unset !important;
+                background-color: #1b232d !important;
+
+                .title {
+                    color: var(--whiteColor);
+                }
+                .text-body {
+                    color: rgba(255, 255, 255, .50) !important;
+                }
+                .menu-body {
+                    li {
+                        border-color: rgba(255, 255, 255, 0.09);
+                        color: var(--whiteColor);
+                        
+                        .icon {
+                            background: #293542;
+                        }
+                        &:first-child {
+                            border-color: rgba(255, 255, 255, 0.09);
+                        }
+                    }
+                }
+                a {
+                    color: var(--whiteColor);
+
+                    &:hover {
+                        color: var(--daxaColor);
+                    }
+                }
+            }
+        }
+        &.profile-menu-dropdown {
+            width: 220px;
+            padding: 20px 0;
+            min-width: auto;
+            max-width: 100%;
+            overflow: hidden;
+            margin-top: 10px;
+            border-radius: 15px;
+            box-shadow: 0px 4px 34px rgba(101, 96, 240, 0.1);
+
+            .menu-header {
+                border-bottom: 1px dashed #e7e2e2;
+                margin-bottom: 10px;
+                padding: {
+                    left: 20px;
+                    right: 20px;
+                    bottom: 20px;
+                };
+                img {
+                    width: 40px;
+                    border-radius: 50%;
+                }
+                .title {
+                    margin-left: 12px;
+
+                    a {
+                        font-size: 17px;
+                    }
+                    .designation {
+                        margin-top: 4px;
+                        font-size: 15px;
+                    }
+                }
+            }
+            .menu-body {
+                li {
+                    padding: 10px 20px 10px 48px;
+                    font-size: 15px;
+
+                    i {
+                        top: 50%;
+                        left: 20px;
+                        line-height: 1;
+                        font-size: 20px;
+                        margin-top: -0.2px;
+                        position: absolute;
+                        color: var(--daxaColor);
+                        transform: translateY(-50%);
+                    }
+                    .link-btn {
+                        top: 0;
+                        left: 0;
+                        right: 0;
+                        bottom: 0;
+                        z-index: 1;
+                    }
+                    &:hover {
+                        background-color: #f2f1f9;
+                        color: var(--daxaColor);
+                    }
+                }
+            }
+            .mat-mdc-menu-content {
+                padding: 0;
+            }
+            &:has(.dark-menu) {
+                color: var(--whiteColor);
+                box-shadow: unset !important;
+                background-color: #1b232d !important;
+
+                a {
+                    color: var(--whiteColor);
+
+                    &:hover {
+                        color: var(--daxaColor);
+                    }
+                }
+                .menu-header {
+                    border-color: rgba(255, 255, 255, 0.09);
+                }
+                .text-body {
+                    color: rgba(255, 255, 255, .50) !important;
+                }
+                .menu-body {
+                    li {
+                        &:hover {
+                            background-color: #2c343e;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* Max width 767px */
+@media only screen and (max-width : 767px) {
+
+    ::ng-deep {
+        .header-area {
+            top: 15px;
+            left: 15px;
+            right: 15px;
+            padding: 15px 15px 12px;
+        
+            .header-left-side {
+                justify-content: center;
+
+                .search-box {
+                    width: 280px;
+        
+                    i {
+                        font-size: 18px;
+                    }
+                    .input-search {
+                        padding: {
+                            left: 38px;
+                            right: 15px;
+                        };
+                    }
+                }
+            }
+            .header-right-side {
+                top: 0;
+                justify-content: center;
+                margin-top: 15px !important;
+    
+                li {
+                    .language-menu-btn {
+                        margin-right: 10px;
+                        padding: 0 15px 0 0;
+
+                        &::after {
+                            font-size: 14px;
+                        }
+                    }
+                    .calendar-menu-btn {
+                        margin: {
+                            left: 15px;
+                            top: -3px;
+                        };
+                    }
+                    .messages-menu-btn {
+                        margin-left: 15px;
+    
+                        i {
+                            margin-right: -7px;
+                        }
+                        .daxa-badge {
+                            width: 15px;
+                            height: 15px;
+                            font-size: 9px;
+                            line-height: 15px;
+                        }
+                    }
+                    .notifications-menu-btn {
+                        margin-left: 12px;
+    
+                        i {
+                            margin-right: -10px;
+                        }
+                        .daxa-badge {
+                            width: 15px;
+                            height: 15px;
+                            font-size: 9px;
+                            line-height: 15px;
+                        }
+                    }
+                    .profile-menu-btn {
+                        margin-left: 13px;
+                        padding: 0 15px 0 0;
+    
+                        img {
+                            width: 35px;
+                        }
+                        &::after {
+                            font-size: 14px;
+                        }
+                    }
+                }
+            }
+            &.sticky {
+                top: 0;
+            }
+            &.active, &.hide-sidebar {
+                left: 15px;
+            }
+            &.right-sidebar {
+                left: 15px;
+                right: 15px;
+    
+                &.active, &.hide-sidebar {
+                    right: 15px;
+                }
+            }
+            &.rtl-enabled {
+                left: 15px;
+                right: 15px;
+
+                .header-left-side {
+                    .search-box {
+                        .input-search {
+                            padding: {
+                                right: 38px;
+                                left: 15px;
+                            };
+                        }
+                    }
+                }
+                .header-right-side {
+                    li {
+                        .language-menu-btn {
+                            padding: 0 0 0 15px;
+                            margin: {
+                                left: 10px;
+                                right: 0;
+                            };
+                        }
+                        .calendar-menu-btn {
+                            margin: {
+                                left: 0;
+                                right: 15px;
+                            };
+                        }
+                        .messages-menu-btn {
+                            margin: {
+                                left: 0;
+                                right: 15px;
+                            };
+                            i {
+                                margin: {
+                                    left: -7px;
+                                    right: 0;
+                                };
+                            }
+                        }
+                        .notifications-menu-btn {
+                            margin: {
+                                left: 0;
+                                right: 12px;
+                            };
+                            i {
+                                margin: {
+                                    right: 0;
+                                    left: -10px;
+                                };
+                            }
+                        }
+                        .profile-menu-btn {
+                            padding: 0 0 0 15px;
+                            margin: {
+                                left: 0;
+                                right: 13px;
+                            };
+                        }
+                    }
+                }
+                &.active, &.hide-sidebar {
+                    left: 15px;
+                    right: 15px;
+                }
+                &.right-sidebar {
+                    right: 15px;
+                    left: 15px;
+        
+                    &.active, &.hide-sidebar {
+                        left: 15px;
+                    }
+                }
+            }
+        }
+        .mat-mdc-menu-panel {
+            &.language-menu-dropdown {
+                width: 200px;
+                max-width: 200px;
+                padding: 15px 0 0;
+    
+                .title {
+                    padding: 0 15px 15px;
+                }
+                .menu-body {
+                    li {
+                        .mdc-button {
+                            padding: 13px 15px;
+                            
+                            .mdc-button__label {
+                                font-size: 14px;
+
+                                img {
+                                    margin-right: 9px;
+                                    width: 27px;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            &.messages-menu-dropdown {
+                width: 300px;
+                padding: 15px 0;
+                max-width: 300px;
+    
+                .title {
+                    padding: {
+                        left: 15px;
+                        right: 15px;
+                        bottom: 15px;
+                    };
+                    .link-btn {
+                        font-size: 13px;
+                    }
+                }
+                .menu-body {
+                    margin-bottom: 15px;
+    
+                    li {
+                        padding: 16px 15px 16px 69px;
+    
+                        img {
+                            left: 15px;
+                        }
+                        .sub-title {
+                            margin-bottom: 5px;
+                            
+                            span {
+                                font-size: 13px;
+                            }
+                        }
+                        .message {
+                            font-size: 13px;
+                        }
+                        .unread {
+                            width: 6px;
+                            right: 15px;
+                            height: 6px;
+                        }
+                    }
+                }
+                .menu-footer {
+                    a {
+                        font-size: 13px;
+                    }
+                }
+            }
+            &.notifications-menu-dropdown {
+                width: 300px;
+                padding: 15px 0;
+                max-width: 300px;
+    
+                .title {
+                    padding: {
+                        left: 15px;
+                        right: 15px;
+                        bottom: 15px;
+                    };
+                    .link-btn {
+                        font-size: 13px;
+                    }
+                }
+                .menu-body {
+                    margin-bottom: 15px;
+    
+                    li {
+                        padding: 15px 15px 15px 64px;
+    
+                        .icon {
+                            left: 15px;
+                            width: 40px;
+                            height: 40px;
+    
+                            i {
+                                font-size: 18px;
+                            }
+                        }
+                        .unread {
+                            width: 6px;
+                            right: 15px;
+                            height: 6px;
+                        }
+                        .time {
+                            font-size: 13px;
+                        }
+                    }
+                }
+                .menu-footer {
+                    a {
+                        font-size: 13px;
+                    }
+                }
+            }
+            &.profile-menu-dropdown {
+                padding: 15px 0;
+    
+                .menu-header {
+                    margin-bottom: 8px;
+                    padding: {
+                        left: 15px;
+                        right: 15px;
+                        bottom: 15px;
+                    };
+                    .title {
+                        margin-left: 11px;
+    
+                        a {
+                            font-size: 15px;
+                        }
+                        .designation {
+                            font-size: 14px;
+                        }
+                    }
+                }
+                .menu-body {
+                    li {
+                        padding: 8px 15px 8px 41px;
+                        font-size: 14px;
+    
+                        i {
+                            left: 15px;
+                            font-size: 18px;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 576px to Max width 767px */
+@media only screen and (min-width : 576px) and (max-width : 767px) {}
+
+/* Min width 768px to Max width 991px */
+@media only screen and (min-width : 768px) and (max-width : 991px) {
+
+    ::ng-deep {
+        .header-area {
+            left: 25px;
+            right: 25px;
+            padding: 12px 15px;
+        
+            .header-left-side {
+                .burger-menu {
+                    margin-right: 20px;
+                }
+                .search-box {
+                    width: 290px;
+                }
+            }
+            .header-right-side {
+                li {
+                    .language-menu-btn {
+                        margin-right: 14px;
+                        padding: 0 18px 0 0;
+                    }
+                    .calendar-menu-btn {
+                        margin-left: 19px;
+                    }
+                    .messages-menu-btn {
+                        margin-left: 20px;
+                    }
+                    .notifications-menu-btn {
+                        margin-left: 17px;
+                    }
+                    .profile-menu-btn {
+                        margin-left: 18px;
+    
+                        img {
+                            width: 35px;
+                        }
+                    }
+                }
+            }
+            &.active, &.hide-sidebar {
+                left: 25px;
+            }
+            &.right-sidebar {
+                right: 25px;
+    
+                &.active, &.hide-sidebar {
+                    right: 25px;
+                }
+            }
+            &.rtl-enabled {
+                left: 25px;
+                right: 25px;
+        
+                .header-left-side {
+                    .burger-menu {
+                        margin: {
+                            left: 20px;
+                            right: 0;
+                        };
+                    }
+                }
+                .header-right-side {
+                    li {
+                        .language-menu-btn {
+                            padding: 0 0 0 18px;
+                            margin: {
+                                right: 0;
+                                left: 14px;
+                            };
+                        }
+                        .calendar-menu-btn {
+                            margin: {
+                                left: 0;
+                                right: 19px;
+                            };
+                        }
+                        .messages-menu-btn {
+                            margin: {
+                                left: 0;
+                                right: 20px;
+                            };
+                        }
+                        .notifications-menu-btn {
+                            margin: {
+                                left: 0;
+                                right: 17px;
+                            };
+                        }
+                        .profile-menu-btn {
+                            margin: {
+                                left: 0;
+                                right: 18px;
+                            };
+                        }
+                    }
+                }
+                &.active, &.hide-sidebar {
+                    left: 25px;
+                    right: 25px;
+                }
+                &.right-sidebar {
+                    right: 25px;
+                    left: 25px;
+        
+                    &.active, &.hide-sidebar {
+                        left: 25px;
+                    }
+                }
+            }
+        }
+        .mat-mdc-menu-panel {
+            &.language-menu-dropdown {
+                padding: 18px 0 0;
+    
+                .title {
+                    padding: 0 20px 18px;
+                }
+                .menu-body {
+                    li {
+                        .mdc-button {
+                            padding: 13px 20px;
+                            
+                            .mdc-button__label {
+                                font-size: 14px;
+                            }
+                        }
+                    }
+                }
+            }
+            &.messages-menu-dropdown {
+                width: 350px;
+                padding: 20px 0;
+                max-width: 350px;
+    
+                .title {
+                    padding: {
+                        left: 20px;
+                        right: 20px;
+                        bottom: 20px;
+                    };
+                    .link-btn {
+                        font-size: 14px;
+                    }
+                }
+                .menu-body {
+                    margin-bottom: 20px;
+    
+                    li {
+                        padding: 18px 20px 18px 75px;
+    
+                        img {
+                            left: 20px;
+                        }
+                        .sub-title {
+                            span {
+                                font-size: 13.5px;
+                            }
+                        }
+                        .message {
+                            font-size: 13.5px;
+                        }
+                        .unread {
+                            right: 20px;
+                        }
+                    }
+                }
+                .menu-footer {
+                    a {
+                        font-size: 14px;
+                    }
+                }
+            }
+            &.notifications-menu-dropdown {
+                width: 350px;
+                padding: 20px 0;
+                max-width: 350px;
+    
+                .title {
+                    padding: {
+                        left: 20px;
+                        right: 20px;
+                        bottom: 20px;
+                    };
+                    .link-btn {
+                        font-size: 14px;
+                    }
+                }
+                .menu-body {
+                    margin-bottom: 20px;
+    
+                    li {
+                        padding: 17px 20px 17px 74px;
+    
+                        .icon {
+                            left: 20px;
+                        }
+                        .unread {
+                            right: 20px;
+                        }
+                        .time {
+                            font-size: 13.5px;
+                        }
+                    }
+                }
+                .menu-footer {
+                    a {
+                        font-size: 14px;
+                    }
+                }
+            }
+            &.profile-menu-dropdown {
+                .menu-header {
+                    margin-bottom: 8px;
+                    
+                    .title {
+                        margin-left: 11px;
+    
+                        a {
+                            font-size: 16px;
+                        }
+                        .designation {
+                            font-size: 14px;
+                        }
+                    }
+                }
+                .menu-body {
+                    li {
+                        padding: 10px 20px 10px 47px;
+                        font-size: 14px;
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 992px to Max width 1199px */
+@media only screen and (min-width : 992px) and (max-width : 1199px) {
+
+    ::ng-deep {
+        .header-area {
+            left: 25px;
+        
+            .header-left-side {
+                .search-box {
+                    width: 320px;
+                }
+            }
+            &.active, &.hide-sidebar {
+                left: 25px;
+            }
+            &.right-sidebar {
+                right: 25px;
+    
+                &.active, &.hide-sidebar {
+                    right: 25px;
+                }
+            }
+            &.rtl-enabled {
+                left: 25px;
+                right: 25px;
+
+                &.active, &.hide-sidebar {
+                    left: 25px;
+                    right: 25px;
+                }
+                &.right-sidebar {
+                    right: 25px;
+                    left: 25px;
+        
+                    &.active, &.hide-sidebar {
+                        left: 25px;
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 1200px to Max width 1399px */
+@media only screen and (min-width: 1200px) and (max-width: 1399px) {
+
+    ::ng-deep {
+        .header-area {
+            left: 262px;
+
+            &.active, &.hide-sidebar {
+                left: 85px;
+            }
+            &.right-sidebar {
+                right: 262px;
+    
+                &.active, &.hide-sidebar {
+                    right: 85px;
+                }
+            }
+            &.rtl-enabled {
+                left: 25px;
+                right: 262px;
+
+                &.active, &.hide-sidebar {
+                    left: 25px;
+                    right: 85px;
+                }
+                &.right-sidebar {
+                    right: 25px;
+                    left: 262px;
+        
+                    &.active, &.hide-sidebar {
+                        left: 85px;
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 1600px */
+@media only screen and (min-width: 1600px) {}

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -1,30 +1,53 @@
-import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
 import { NgClass } from '@angular/common';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { Component, HostListener } from '@angular/core';
+import { ToggleService } from '../sidebar/toggle.service';
 import { MatButtonModule } from '@angular/material/button';
-import { NgScrollbarModule } from 'ngx-scrollbar';
+import { RouterLink, RouterLinkActive } from '@angular/router';
 import {CustomizerSettingsService} from "../../services/customizer-settings/customizer-settings.service";
 
 @Component({
-    selector: 'app-customizer-settings',
+    selector: 'app-header',
     standalone: true,
-    imports: [RouterLink, NgClass, MatDividerModule, MatIconModule, MatButtonModule, NgScrollbarModule],
-    templateUrl: './customizer-settings.component.html',
-    styleUrl: './customizer-settings.component.scss'
+    imports: [NgClass, MatMenuModule, MatButtonModule, RouterLink, RouterLinkActive],
+    templateUrl: './header.component.html',
+    styleUrl: './header.component.scss'
 })
-export class CustomizerSettingsComponent {
+export class HeaderComponent {
+
+    // isSidebarToggled
+    isSidebarToggled = false;
 
     // isToggled
     isToggled = false;
 
     constructor(
+        private toggleService: ToggleService,
         public themeService: CustomizerSettingsService
     ) {
+        this.toggleService.isSidebarToggled$.subscribe(isSidebarToggled => {
+            this.isSidebarToggled = isSidebarToggled;
+        });
         this.themeService.isToggled$.subscribe(isToggled => {
             this.isToggled = isToggled;
         });
+    }
+
+    // Burger Menu Toggle
+    toggle() {
+        this.toggleService.toggle();
+    }
+
+    // Header Sticky
+    isSticky: boolean = false;
+    @HostListener('window:scroll', ['$event'])
+    checkScroll() {
+        const scrollPosition = window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
+        if (scrollPosition >= 50) {
+            this.isSticky = true;
+        } else {
+            this.isSticky = false;
+        }
     }
 
     // Dark Mode
@@ -57,19 +80,9 @@ export class CustomizerSettingsComponent {
         this.themeService.toggleCardBorderTheme();
     }
 
-    // Card Border Radius
-    toggleCardBorderRadiusTheme() {
-        this.themeService.toggleCardBorderRadiusTheme();
-    }
-
     // RTL Mode
     toggleRTLEnabledTheme() {
         this.themeService.toggleRTLEnabledTheme();
-    }
-
-    // Settings Button Toggle
-    toggle() {
-        this.themeService.toggle();
     }
 
 }

--- a/src/app/shared/components/sidebar/sidebar.component.html
+++ b/src/app/shared/components/sidebar/sidebar.component.html
@@ -1,0 +1,1144 @@
+<div
+    class="sidebar-area bg-white active"
+    [ngClass]="{'active': isSidebarToggled}"
+    [class.component-dark-theme]="themeService.isDark()"
+    [class.dark-sidebar]="themeService.isSidebarDark()"
+    [class.right-sidebar]="themeService.isRightSidebar()"
+    [class.hide-sidebar]="themeService.isHideSidebar()"
+    [class.card-borderd-theme]="themeService.isCardBorder()"
+    [class.rtl-enabled]="themeService.isRTLEnabled()"
+>
+    <div class="logo bg-white">
+        <a routerLink="/" class="d-flex align-items-center">
+            <img src="assets/images/logo-icon.svg" alt="logo-icon">
+            <span class="fw-semibold">Enterprise</span>
+        </a>
+    </div>
+    <div
+        (click)="toggle()"
+        class="burger-menu"
+        [ngClass]="{'active': isSidebarToggled}"
+    >
+        <span class="top-bar"></span>
+        <span class="middle-bar"></span>
+        <span class="bottom-bar"></span>
+    </div>
+    <ng-scrollbar visibility="hover">
+        <div class="sidebar-inner">
+            <div class="sidebar-menu">
+                <mat-accordion>
+                    <span class="sub-title text-body">
+                        MAIN
+                    </span>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    dashboard
+                                </i>
+                                <span class="title">
+                                    Dashboard
+                                </span>
+                                <span class="daxa-badge">
+                                    5
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    E-Commerce
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/crm" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    CRM
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Project Management
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/lms" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    LMS
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/help-desk" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Help Desk <span class="daxa-badge">Hot</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <span class="sub-title text-body">
+                        APPS
+                    </span>
+                    <a routerLink="/to-do-list" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            ballot
+                        </i>
+                        <span class="title">
+                            To Do List
+                        </span>
+                    </a>
+                    <a routerLink="/calendar" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            calendar_today
+                        </i>
+                        <span class="title">
+                            Calendar
+                        </span>
+                    </a>
+                    <a routerLink="/contacts" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            perm_contact_calendar
+                        </i>
+                        <span class="title">
+                            Contacts
+                        </span>
+                    </a>
+                    <a routerLink="/kanban-board" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            keyboard_command_key
+                        </i>
+                        <span class="title">
+                            Kanban Board
+                        </span>
+                    </a>
+                    <span class="sub-title text-body">
+                        PAGES
+                    </span>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    shopping_cart
+                                </i>
+                                <span class="title">
+                                    E-Commerce
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Products Grid
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/products-list" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Products List
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/product-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Product Details
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/create-product" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Create Product
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/edit-product" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Edit Product
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/cart" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Cart
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/checkout" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Checkout
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/orders" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Orders
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/order-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Order Details
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/create-order" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Create Order
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/order-tracking" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Order Tracking
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/customers" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Customers
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/customer-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Customer Details
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/categories" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Categories
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/create-category" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Create Category
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/edit-category" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Edit Category
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/sellers" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Sellers
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/seller-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Seller Details
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/create-seller" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Create Seller
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/reviews" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Reviews
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ecommerce-page/refunds" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Refunds
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    handshake
+                                </i>
+                                <span class="title">
+                                    CRM
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/crm-page" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Contacts
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/crm-page/customers" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Customers
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/crm-page/leads" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Leads
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/crm-page/deals" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Deals
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    description
+                                </i>
+                                <span class="title">
+                                    Project Management
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management-page" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Project Overview
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management-page/projects-list" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Projects List
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management-page/create-project" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Create Project
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management-page/clients" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Clients
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management-page/teams" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Teams
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management-page/kanban-board" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Kanban Board
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/project-management-page/users" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Users
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    auto_stories
+                                </i>
+                                <span class="title">
+                                    LMS
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/lms-page" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Courses List
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/lms-page/course-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Course Details
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/lms-page/create-course" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Create Course
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/lms-page/edit-course" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Edit Course
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/lms-page/instructors" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Instructors
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    support
+                                </i>
+                                <span class="title">
+                                    Help Desk
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/help-desk-page" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Tickets
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/help-desk-page/ticket-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Ticket Details
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/help-desk-page/agents" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Agents
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/help-desk-page/reports" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Reports
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    local_activity
+                                </i>
+                                <span class="title">
+                                    Events
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/events" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Events
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/events/event-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Event Details
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/events/create-an-event" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Create An Event
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/events/edit-an-event" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Edit An Event
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    share
+                                </i>
+                                <span class="title">
+                                    Social
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/social" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Profile
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/social/settings" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Settings
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    content_paste
+                                </i>
+                                <span class="title">
+                                    Invoices
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/invoices" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Invoices
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/invoices/invoice-details" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Invoice Details
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    person
+                                </i>
+                                <span class="title">
+                                    Users
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/users" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Team Members
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/users/users-list" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Users List
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/users/add-user" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Add User
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    account_box
+                                </i>
+                                <span class="title">
+                                    Profile
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/profile" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    User Profile
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/profile/teams" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Teams
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/profile/projects" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Projects
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <a routerLink="/starter" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            star_border
+                        </i>
+                        <span class="title">
+                            Starter
+                        </span>
+                    </a>
+                    <span class="sub-title text-body">
+                        MODULES
+                    </span>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    emoji_emotions
+                                </i>
+                                <span class="title">
+                                    Icons
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/icons" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Material Symbols
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/icons/remixicon" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    RemixIcon
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    qr_code_scanner
+                                </i>
+                                <span class="title">
+                                    UI Elements
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Alerts
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/autocomplete" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Autocomplete
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/avatars" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Avatars
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/accordion" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Accordion
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/badges" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Badges
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/breadcrumb" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Breadcrumb
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/button-toggle" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Button Toggle
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/bottom-sheet" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Bottom Sheet
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/buttons" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Buttons
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/cards" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Cards
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/carousels" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Carousels
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/checkbox" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Checkbox
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/chips" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Chips
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/clipboard" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Clipboard
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/color-picker" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Color Picker
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/datepicker" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Datepicker
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/dialog" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Dialog
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/divider" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Divider
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/drag-drop" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Drag & Drop
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/expansion" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Expansion
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/form-field" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Form Field
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/grid-list" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Grid List
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/icon" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Icon
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/input" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Input
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/list" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    List
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/listbox" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Listbox
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/menus" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Menus
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/pagination" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Pagination
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/progress-bar" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Progress Bar
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/radio" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Radio
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/ratio" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Ratio
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/select" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Select
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/sidenav" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Sidenav
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/slide-toggle" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Slide Toggle
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/slider" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Slider
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/snackbar" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Snackbar
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/stepper" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Stepper
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/table" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Table
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/tabs" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Tabs
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/toolbar" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Toolbar
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/tooltip" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Tooltip
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/tree" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Tree
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/typography" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Typography
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/videos" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Videos
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/ui-kit/utilities" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    _Utilities
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    table_chart
+                                </i>
+                                <span class="title">
+                                    Tables
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/tables" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Basic Table
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/tables/data-table" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Data Table
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    forum
+                                </i>
+                                <span class="title">
+                                    Forms
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/forms" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Basic Elements
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/forms/advanced-elements" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Advanced Elements
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/forms/wizard" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Wizard
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/forms/editors" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Editors
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/forms/file-uploader" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    File Uploader
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    lock_open
+                                </i>
+                                <span class="title">
+                                    Authentication
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/authentication" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Sign In
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/authentication/sign-up" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Sign Up
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/authentication/forgot-password" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Forgot Password
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/authentication/reset-password" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Reset Password
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/authentication/confirm-email" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Confirm Email
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/authentication/lock-screen" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Lock Screen
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/authentication/logout" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Logout
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    content_copy
+                                </i>
+                                <span class="title">
+                                    Extra Pages
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/pricing" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Pricing
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/timeline" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Timeline
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/faq" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    FAQ
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/gallery" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Gallery
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/testimonials" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Testimonials
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/search" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Search
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/coming-soon" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Coming Soon
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/blank-page" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Blank Page
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    error
+                                </i>
+                                <span class="title">
+                                    Errors
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/not-found" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    404 Error Page
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/internal-error" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Internal Error
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <a routerLink="/widgets" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            widgets
+                        </i>
+                        <span class="title">
+                            Widgets
+                        </span>
+                    </a>
+                    <a routerLink="/maps" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            map
+                        </i>
+                        <span class="title">
+                            Maps
+                        </span>
+                    </a>
+                    <a routerLink="/notifications" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            notifications
+                        </i>
+                        <span class="title">
+                            Notifications
+                        </span>
+                    </a>
+                    <a routerLink="/members" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            people
+                        </i>
+                        <span class="title">
+                            Members
+                        </span>
+                    </a>
+                    <span class="sub-title text-body">
+                        OTHERS
+                    </span>
+                    <a routerLink="/my-profile" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            account_circle
+                        </i>
+                        <span class="title">
+                            My Profile
+                        </span>
+                    </a>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    settings
+                                </i>
+                                <span class="title">
+                                    Settings
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <ul class="sidebar-sub-menu">
+                            <li class="sidemenu-item">
+                                <a routerLink="/settings" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Account Settings
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/settings/change-password" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Change Password
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/settings/connections" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Connections
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/settings/privacy-policy" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Privacy Policy
+                                </a>
+                            </li>
+                            <li class="sidemenu-item">
+                                <a routerLink="/settings/terms-conditions" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                    Terms & Conditions
+                                </a>
+                            </li>
+                        </ul>
+                    </mat-expansion-panel>
+                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                <i class="material-symbols-outlined">
+                                    unfold_more
+                                </i>
+                                <span class="title">
+                                    Multi Level Menu
+                                </span>
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <mat-accordion>
+                            <ul class="sidebar-sub-menu">
+                                <li class="sidemenu-item">
+                                    <a href="javascript:void(0)" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                        First
+                                    </a>
+                                </li>
+                                <li class="sidemenu-item">
+                                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                                        <mat-expansion-panel-header>
+                                            <mat-panel-title>
+                                                Second
+                                            </mat-panel-title>
+                                        </mat-expansion-panel-header>
+                                        <ul class="sidebar-sub-menu">
+                                            <li class="sidemenu-item">
+                                                <a href="javascript:void(0)" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                                    Second 1
+                                                </a>
+                                            </li>
+                                            <li class="sidemenu-item">
+                                                <mat-accordion>
+                                                    <mat-expansion-panel (opened)="panelOpenState = true" (closed)="panelOpenState = true">
+                                                        <mat-expansion-panel-header>
+                                                            <mat-panel-title>
+                                                                Second 2
+                                                            </mat-panel-title>
+                                                        </mat-expansion-panel-header>
+                                                        <ul class="sidebar-sub-menu">
+                                                            <li class="sidemenu-item">
+                                                                <a href="javascript:void(0)" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                                                    Third 1
+                                                                </a>
+                                                            </li>
+                                                        </ul>
+                                                    </mat-expansion-panel>
+                                                </mat-accordion>
+                                            </li>
+                                        </ul>
+                                    </mat-expansion-panel>
+                                </li>
+                                <li class="sidemenu-item">
+                                    <a href="javascript:void(0)" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="sidemenu-link">
+                                        Third
+                                    </a>
+                                </li>
+                            </ul>
+                        </mat-accordion>
+                    </mat-expansion-panel>
+                    <a routerLink="/authentication/logout" class="sidebar-menu-link" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+                        <i class="material-symbols-outlined">
+                            logout
+                        </i>
+                        <span class="title">Logout</span>
+                    </a>
+                </mat-accordion>
+            </div>
+        </div>
+    </ng-scrollbar>
+</div>

--- a/src/app/shared/components/sidebar/sidebar.component.scss
+++ b/src/app/shared/components/sidebar/sidebar.component.scss
@@ -1,0 +1,1229 @@
+::ng-deep {
+    .sidebar-area {
+        transition: var(--transition);
+        overflow: hidden;
+        position: fixed;
+        height: 100vh;
+        width: 260px;
+        z-index: 222;
+        left: 0;
+        top: 0;
+        
+        .logo {
+            position: absolute;
+            padding: 25px;
+            z-index: 2;
+            right: 0;
+            left: 0;
+            top: 0;
+            
+            a {
+                color: var(--blackColor);
+                font: {
+                    weight: 700;
+                    size: 24px;
+                };
+                span {
+                    margin-left: 10px;
+                }
+            }
+        }
+        .burger-menu {
+            top: 29px;
+            z-index: 3;
+            right: 25px;
+            cursor: pointer;
+            position: absolute;
+            transition: var(--transition);
+    
+            span {
+                height: 1px;
+                width: 25px;
+                margin: 6px 0;
+                display: block;
+                background: var(--blackColor);
+                transition: var(--transition);
+            }
+            &.active {
+                opacity: 1;
+                visibility: visible;
+                
+                span {
+                    &.top-bar {
+                        transform: rotate(45deg);
+                        transform-origin: 10% 10%;
+                    }
+                    &.middle-bar {
+                        opacity: 0;
+                    }
+                    &.bottom-bar {
+                        transform: rotate(-45deg);
+                        transform-origin: 10% 90%;
+                        margin-top: 5px;
+                    }
+                }
+            }
+        }
+        .ng-scrollbar {
+            height: 100vh;
+        }
+        .sidebar-inner {
+            padding: {
+                top: 100px;
+                left: 25px;
+                right: 25px;
+                bottom: 20px;
+            };
+            .sidebar-menu {
+                .sub-title {
+                    display: block;
+                    font-size: 14px;
+                    position: relative;
+                    padding-left: 22px;
+                    margin-bottom: 19px;
+
+                    &::before {
+                        left: 0;
+                        top: 50%;
+                        content: '';
+                        height: 1px;
+                        width: 12px;
+                        position: absolute;
+                        background: #a6acbe;
+                        transform: translateY(-50%);
+                    }
+                }
+                .mat-accordion {
+                    .mat-expansion-panel {
+                        border-radius: 0;
+                        box-sizing: unset;
+                        margin-bottom: 27px;
+                        color: var(--blackColor);
+                        background-color: transparent;
+            
+                        .mat-expansion-panel-header {
+                            transition: var(--transition);
+                            background-color: transparent;
+                            color: var(--blackColor);
+                            position: relative;
+                            font-size: 15px;
+                            display: block;
+                            height: auto;
+                            padding: {
+                                right: 43px;
+                                left: 24px;
+                            };
+                            i {
+                                transform: translateY(-50%);
+                                position: absolute;
+                                margin-top: -.5px;
+                                font-size: 17px;
+                                line-height: 1;
+                                top: 50%;
+                                left: 0;
+                            }
+                            .mat-content {
+                                display: block;
+            
+                                .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                    display: block;
+                                    margin-right: 0;
+                                    color: var(--blackColor);
+                                    transition: var(--transition);
+                                }
+                            }
+                            &.mat-expanded {
+                                color: var(--daxaColor);
+
+                                .mat-content {
+                                    .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                        color: var(--daxaColor);
+                                    }
+                                }
+                                .mat-expansion-indicator {
+                                    &::before {
+                                        content: "\ea4e";
+                                    }
+                                }
+                            }
+                            .mat-expansion-indicator {
+                                transform: translateY(-50%) !important;
+                                position: absolute;
+                                right: 0;
+                                top: 50%;
+            
+                                &::after {
+                                    display: none;
+                                }
+                                &::before {
+                                    font-size: 15px;
+                                    content: "\ea6e";
+                                    position: relative;
+                                    display: inline-block;
+                                    color: var(--blackColor);
+                                    transition: var(--transition);
+                                    font-family: remixicon!important;
+                                }
+                            }
+                            .daxa-badge {
+                                top: 50%;
+                                right: 20px;
+                                width: 17px;
+                                height: 17px;
+                                line-height: 17px;
+                                text-align: center;
+                                border-radius: 50%;
+                                position: absolute;
+                                display: inline-block;
+                                color: var(--daxaColor);
+                                transform: translateY(-50%);
+                                background: rgba(117, 127, 239, 0.1);
+                                font: {
+                                    size: 11px;
+                                    weight: 500;
+                                };
+                                &.two {
+                                    color: #00b69b;
+                                    background: rgba(0, 182, 155, 0.07);
+                                }
+                                &.three {
+                                    color: #ee368c;
+                                    background: rgba(238, 54, 140, 0.1);
+                                }
+                            }
+                            &:hover {
+                                color: var(--daxaColor);
+
+                                .mat-content {
+                                    .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                        color: var(--daxaColor);
+                                    }
+                                }
+                                .mat-expansion-indicator {
+                                    &::before {
+                                        color: var(--daxaColor);
+                                    }
+                                }
+                            }
+                        }
+                        &:not([class*=mat-elevation-z]) {
+                            box-shadow: unset;
+                        }
+                        &:first-of-type {
+                            border-radius: 0;
+                        }
+                        .mat-expansion-panel-content {
+                            display: block;
+                        }
+                        .mat-expansion-panel-body {
+                            padding: 15px 0 0;
+            
+                            .mat-expansion-panel {
+                                margin-bottom: 0;
+                            }
+                            .mat-expansion-panel-header {
+                                font-size: 14px;
+                                border-radius: 5px;
+                                padding: {
+                                    bottom: 11px;
+                                    left: 32px;
+                                    top: 11px;
+                                };
+                                &::after {
+                                    top: 50%;
+                                    left: 15px;
+                                    width: 6px;
+                                    height: 6px;
+                                    content: '';
+                                    transition: .3s;
+                                    border-radius: 50%;
+                                    position: absolute;
+                                    transform: translateY(-50%);
+                                    background-color: #adadb9;
+                                }
+                                .mat-content {
+                                    .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                        color: var(--blackColor) !important;
+                                        transition: var(--transition);
+                                    }
+                                }
+                                .mat-expansion-indicator {
+                                    right: 11px;
+
+                                    &::before {
+                                        color: var(--blackColor) !important;
+                                    }
+                                }
+                                &.mat-expanded {
+                                    background-color: #e7effd !important;
+                                    color: var(--daxaColor);
+            
+                                    .mat-content {
+                                        .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                            color: var(--daxaColor) !important;
+                                        }
+                                    }
+                                    &::after {
+                                        background-color: var(--daxaColor);
+                                    }
+                                    .mat-expansion-indicator {
+                                        &::before {
+                                            color: var(--daxaColor) !important;
+                                        }
+                                    }
+                                }
+                                &:hover {
+                                    background-color: #e7effd !important;
+                                    color: var(--daxaColor);
+            
+                                    .mat-content {
+                                        .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                            color: var(--daxaColor);
+                                        }
+                                    }
+                                    &::after {
+                                        background-color: var(--daxaColor);
+                                    }
+                                }
+                            }
+                            .mat-expansion-panel-body {
+                                padding: {
+                                    top: 6px;
+                                    left: 20px;
+                                };
+                            }
+                            .sidebar-sub-menu {
+                                padding-left: 0;
+                                list-style-type: none;
+                                margin: {
+                                    top: 0;
+                                    bottom: 0;
+                                };
+                                .sidemenu-item {
+                                    .sidemenu-link {
+                                        display: block;
+                                        font-size: 14px;
+                                        position: relative;
+                                        border-radius: 5px;
+                                        color: var(--blackColor);
+                                        transition: var(--transition);
+                                        padding: {
+                                            bottom: 11px;
+                                            left: 32px;
+                                            top: 11px;
+                                        };
+                                        &::after {
+                                            top: 50%;
+                                            left: 15px;
+                                            width: 6px;
+                                            height: 6px;
+                                            content: '';
+                                            transition: .3s;
+                                            border-radius: 50%;
+                                            position: absolute;
+                                            transform: translateY(-50%);
+                                            background-color: #adadb9;
+                                        }
+                                        &:hover, &.active {
+                                            background-color: #e7effd;
+                                            color: var(--daxaColor);
+            
+                                            &::after {
+                                                background-color: var(--daxaColor);
+                                            }
+                                        }
+                                        .daxa-badge {
+                                            font-size: 11px;
+                                            padding: 3px 8px;
+                                            margin-left: 5px;
+                                            border-radius: 2px;
+                                            color: var(--whiteColor);
+                                            background-color: var(--daxaColor);
+                                        }
+                                    }
+                                    .mat-expansion-panel {
+                                        margin-bottom: 0;
+                                    }
+                                }
+                            }
+                        }
+                        &:has(> .mat-expansion-panel-content > .mat-expansion-panel-body > .sidebar-sub-menu > .sidemenu-item > .sidemenu-link.active) {
+                            .mat-expansion-panel-header {
+                                color: var(--daxaColor);
+
+                                .mat-content {
+                                    .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                        color: var(--daxaColor);
+                                    }
+                                }
+                                .mat-expansion-indicator {
+                                    &::before {
+                                        color: var(--daxaColor);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .sidebar-menu-link {
+                        transition: var(--transition);
+                        color: var(--blackColor);
+                        margin-bottom: 27px;
+                        position: relative;
+                        font-size: 15px;
+                        display: block;
+                        padding: {
+                            right: 43px;
+                            left: 24px;
+                        };
+                        i {
+                            transform: translateY(-50%);
+                            position: absolute;
+                            margin-top: -.5px;
+                            font-size: 17px;
+                            line-height: 1;
+                            top: 50%;
+                            left: 0;
+                        }
+                        &:hover, &.active {
+                            color: var(--daxaColor);
+                        }
+                    }
+                }
+            }
+        }
+        &.dark-sidebar, &.component-dark-theme {
+            .logo {
+                a {
+                    color: var(--whiteColor);
+                }
+            }
+            .burger-menu {
+                span {
+                    background: var(--whiteColor);
+                }
+            }
+            .sidebar-inner {
+                .sidebar-menu {
+                    .sub-title {
+                        &::before {
+                            opacity: .50;
+                        }
+                    }
+                    .mat-accordion {
+                        .mat-expansion-panel {
+                            color: var(--whiteColor);
+                
+                            .mat-expansion-panel-header {
+                                color: var(--whiteColor);
+                                
+                                .mat-content {
+                                    .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                        color: var(--whiteColor);
+                                    }
+                                }
+                                &.mat-expanded {
+                                    color: var(--daxaColor);
+    
+                                    .mat-content {
+                                        .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                            color: var(--daxaColor);
+                                        }
+                                    }
+                                }
+                                .mat-expansion-indicator {
+                                    &::before {
+                                        color: var(--whiteColor);
+                                    }
+                                }
+                                &:hover {
+                                    color: var(--daxaColor);
+    
+                                    .mat-content {
+                                        .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                            color: var(--daxaColor);
+                                        }
+                                    }
+                                    .mat-expansion-indicator {
+                                        &::before {
+                                            color: var(--daxaColor);
+                                        }
+                                    }
+                                }
+                            }
+                            .mat-expansion-panel-body {
+                                .mat-expansion-panel-header {
+                                    &::after {
+                                        opacity: .50;
+                                    }
+                                    .mat-content {
+                                        .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                            color: var(--whiteColor) !important;
+                                        }
+                                    }
+                                    .mat-expansion-indicator {
+                                        &::before {
+                                            color: var(--whiteColor) !important;
+                                        }
+                                    }
+                                    &.mat-expanded {
+                                        background-color: #2c343e !important;
+                                        color: var(--daxaColor);
+                
+                                        .mat-content {
+                                            .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                                color: var(--daxaColor) !important;
+                                            }
+                                        }
+                                        &::after {
+                                            background-color: var(--daxaColor);
+                                        }
+                                        .mat-expansion-indicator {
+                                            &::before {
+                                                color: var(--daxaColor) !important;
+                                            }
+                                        }
+                                    }
+                                    &:hover {
+                                        background-color: #2c343e !important;
+                                        color: var(--daxaColor);
+                
+                                        .mat-content {
+                                            .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                                color: var(--daxaColor);
+                                            }
+                                        }
+                                        &::after {
+                                            background-color: var(--daxaColor);
+                                        }
+                                    }
+                                }
+                                .sidebar-sub-menu {
+                                    .sidemenu-item {
+                                        .sidemenu-link {
+                                            color: var(--whiteColor);
+                                            
+                                            &::after {
+                                                opacity: .50;
+                                            }
+                                            &:hover, &.active {
+                                                background-color: #2c343e;
+                                                color: var(--daxaColor);
+                
+                                                &::after {
+                                                    background-color: var(--daxaColor);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            &:has(> .mat-expansion-panel-content > .mat-expansion-panel-body > .sidebar-sub-menu > .sidemenu-item > .sidemenu-link.active) {
+                                .mat-expansion-panel-header {
+                                    color: var(--daxaColor);
+    
+                                    .mat-content {
+                                        .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                            color: var(--daxaColor);
+                                        }
+                                    }
+                                    .mat-expansion-indicator {
+                                        &::before {
+                                            color: var(--daxaColor);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .sidebar-menu-link {
+                            color: var(--whiteColor);
+                            
+                            &:hover, &.active {
+                                color: var(--daxaColor);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        &.dark-sidebar {
+            &.bg-white, .bg-white {
+                background-color: #1b232d !important;
+            }
+            .text-black {
+                color: var(--whiteColor) !important;
+            }
+            .text-body {
+                color: rgba(255, 255, 255, .50) !important;
+            }
+            .ng-scrollbar {
+                --scrollbar-thumb-color: rgba(255, 255, 255, .1);
+            }
+        }
+        &.card-borderd-theme {
+            box-shadow: var(--borderBoxShadow) !important;
+        }
+        &.right-sidebar {
+            left: auto;
+            right: 0;
+        }
+        &.rtl-enabled {
+            left: auto;
+            right: 0;
+            
+            .logo {
+                a {
+                    span {
+                        margin: {
+                            left: 0;
+                            right: 10px;
+                        };
+                    }
+                }
+            }
+            .burger-menu {
+                right: auto;
+                left: 25px;
+            }
+            .sidebar-inner {
+                .sidebar-menu {
+                    .sub-title {
+                        padding: {
+                            left: 0;
+                            right: 22px;
+                        };
+                        &::before {
+                            left: auto;
+                            right: 0;
+                        }
+                    }
+                    .mat-accordion {
+                        .mat-expansion-panel {
+                            .mat-expansion-panel-header {
+                                padding: {
+                                    left: 43px;
+                                    right: 24px;
+                                };
+                                i {
+                                    left: auto;
+                                    right: 0;
+                                }
+                                .mat-content {
+                                    .mat-expansion-panel-header-title, .mat-expansion-panel-header-description {
+                                        margin: {
+                                            right: 0;
+                                            left: 0;
+                                        };
+                                    }
+                                }
+                                .mat-expansion-indicator {
+                                    right: auto;
+                                    left: 0;
+
+                                    &::before {
+                                        transform: scaleX(-1);
+                                    }
+                                }
+                                .daxa-badge {
+                                    right: auto;
+                                    left: 20px;
+                                }
+                            }
+                            .mat-expansion-panel-body {
+                                .mat-expansion-panel-header {
+                                    padding: {
+                                        right: 32px;
+                                        left: 0;
+                                    };
+                                    &::after {
+                                        left: auto;
+                                        right: 15px;
+                                    }
+                                    .mat-expansion-indicator {
+                                        right: auto;
+                                        left: 11px;
+                                    }
+                                }
+                                .mat-expansion-panel-body {
+                                    padding: {
+                                        left: 0;
+                                        right: 20px;
+                                    };
+                                }
+                                .sidebar-sub-menu {
+                                    padding-right: 0;
+                                    
+                                    .sidemenu-item {
+                                        .sidemenu-link {
+                                            padding: {
+                                                left: 0;
+                                                right: 32px;
+                                            };
+                                            &::after {
+                                                left: auto;
+                                                right: 15px;
+                                            }
+                                            .daxa-badge {
+                                                margin: {
+                                                    left: 0;
+                                                    right: 5px;
+                                                };
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .sidebar-menu-link {
+                            padding: {
+                                left: 43px;
+                                right: 24px;
+                            };
+                            i {
+                                right: 0;
+                                left: auto;
+                            }
+                        }
+                    }
+                }
+            }
+            &.right-sidebar {
+                left: 0;
+                right: auto;
+            }
+        }
+    }
+}
+
+/* Max width 767px */
+@media only screen and (max-width : 767px) {
+
+    ::ng-deep {
+        .sidebar-area {
+            width: 250px;
+            left: -100%;
+            
+            .logo {
+                padding: 20px;
+            }
+            .burger-menu {
+                top: 23px;
+                right: 20px;
+            }
+            .sidebar-inner {
+                padding: {
+                    top: 80px;
+                    left: 20px;
+                    right: 20px;
+                    bottom: 2px;
+                };
+                .sidebar-menu {
+                    .sub-title {
+                        font-size: 13px;
+                        padding-left: 18px;
+                        margin-bottom: 16px;
+    
+                        &::before {
+                            width: 10px;
+                        }
+                    }
+                    .mat-accordion {
+                        .mat-expansion-panel {
+                            margin-bottom: 23px;
+                
+                            .mat-expansion-panel-header {
+                                font-size: 14px;
+                                padding: {
+                                    right: 50px;
+                                    left: 23px;
+                                };
+                                i {
+                                    font-size: 16px;
+                                }
+                                .daxa-badge {
+                                    right: 20px;
+                                    width: 16px;
+                                    height: 16px;
+                                    font-size: 10px;
+                                    line-height: 16px;
+                                }
+                            }
+                            .mat-expansion-panel-body {
+                                padding: 12px 0 0;
+                
+                                .mat-expansion-panel-header {
+                                    font-size: 13px;
+                                    padding: {
+                                        bottom: 10px;
+                                        left: 27px;
+                                        top: 10px;
+                                    };
+                                    &::after {
+                                        left: 13px;
+                                    }
+                                    .mat-expansion-indicator {
+                                        right: 10px;
+                                    }
+                                }
+                                .mat-expansion-panel-body {
+                                    padding: {
+                                        top: 0;
+                                        left: 12px;
+                                    };
+                                }
+                                .sidebar-sub-menu {
+                                    .sidemenu-item {
+                                        .sidemenu-link {
+                                            font-size: 13px;
+                                            padding: {
+                                                bottom: 10px;
+                                                left: 27px;
+                                                top: 10px;
+                                            };
+                                            &::after {
+                                                left: 13px;
+                                            }
+                                            .daxa-badge {
+                                                font-size: 10px;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .sidebar-menu-link {
+                            margin-bottom: 23px;
+                            font-size: 14px;
+                            padding: {
+                                right: 60px;
+                                left: 23px;
+                            };
+                            i {
+                                font-size: 16px;
+                            }
+                        }
+                    }
+                }
+            }
+            &.active, &.hide-sidebar {
+                left: 0;
+            }
+            &.right-sidebar {
+                left: auto;
+                right: -100%;
+
+                &.active, &.hide-sidebar {
+                    right: 0;
+                }
+            }
+            &.rtl-enabled {
+                right: -100%;
+                left: auto;
+
+                .burger-menu {
+                    right: auto;
+                    left: 20px;
+                }
+                .sidebar-inner {
+                    .sidebar-menu {
+                        .sub-title {
+                            padding: {
+                                left: 0;
+                                right: 18px;
+                            };
+                        }
+                        .mat-accordion {
+                            .mat-expansion-panel {
+                                .mat-expansion-panel-header {
+                                    padding: {
+                                        left: 50px;
+                                        right: 23px;
+                                    };
+                                    .daxa-badge {
+                                        right: auto;
+                                        left: 20px;
+                                    }
+                                }
+                                .mat-expansion-panel-body {
+                                    .mat-expansion-panel-header {
+                                        padding: {
+                                            left: 0;
+                                            right: 27px;
+                                        };
+                                        &::after {
+                                            left: auto;
+                                            right: 13px;
+                                        }
+                                        .mat-expansion-indicator {
+                                            right: auto;
+                                            left: 10px;
+                                        }
+                                    }
+                                    .mat-expansion-panel-body {
+                                        padding: {
+                                            right: 12px;
+                                            left: 0;
+                                        };
+                                    }
+                                    .sidebar-sub-menu {
+                                        .sidemenu-item {
+                                            .sidemenu-link {
+                                                padding: {
+                                                    left: 0;
+                                                    right: 27px;
+                                                };
+                                                &::after {
+                                                    left: auto;
+                                                    right: 13px;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            .sidebar-menu-link {
+                                padding: {
+                                    left: 60px;
+                                    right: 23px;
+                                };
+                            }
+                        }
+                    }
+                }
+                &.right-sidebar {
+                    left: -100%;
+                    right: auto;
+    
+                    &.active, &.hide-sidebar {
+                        left: 0;
+                    }
+                }
+                &.active, &.hide-sidebar {
+                    left: auto;
+                    right: 0;
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 576px to Max width 767px */
+@media only screen and (min-width : 576px) and (max-width : 767px) {}
+
+/* Min width 768px to Max width 991px */
+@media only screen and (min-width : 768px) and (max-width : 991px) {
+
+    ::ng-deep {
+        .sidebar-area {
+            left: -100%;
+
+            &.active, &.hide-sidebar {
+                left: 0;
+            }
+            &.right-sidebar {
+                left: auto;
+                right: -100%;
+
+                &.active, &.hide-sidebar {
+                    right: 0;
+                }
+            }
+            &.rtl-enabled {
+                right: -100%;
+                left: auto;
+
+                &.right-sidebar {
+                    left: -100%;
+                    right: 0;
+    
+                    &.active, &.hide-sidebar {
+                        left: 0;
+                    }
+                }
+                &.active, &.hide-sidebar {
+                    left: auto;
+                    right: 0;
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 992px to Max width 1199px */
+@media only screen and (min-width : 992px) and (max-width : 1199px) {
+
+    ::ng-deep {
+        .sidebar-area {
+            left: -100%;
+
+            &.active, &.hide-sidebar {
+                left: 0;
+            }
+            &.right-sidebar {
+                left: auto;
+                right: -100%;
+
+                &.active, &.hide-sidebar {
+                    right: 0;
+                }
+            }
+            &.rtl-enabled {
+                right: -100%;
+                left: auto;
+
+                &.right-sidebar {
+                    left: -100%;
+                    right: 0;
+    
+                    &.active, &.hide-sidebar {
+                        left: 0;
+                    }
+                }
+                &.active, &.hide-sidebar {
+                    left: auto;
+                    right: 0;
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 1200px */
+@media (min-width: 1200px) {
+    
+    ::ng-deep {
+        .sidebar-area {
+            &.active, &.hide-sidebar {
+                width: 60px;
+    
+                .logo {
+                    padding: {
+                        left: 12px;
+                        right: 12px;
+                    };
+                    a {
+                        span {
+                            display: none;
+                        }
+                    }
+                }
+                .burger-menu {
+                    opacity: 0;
+                    visibility: hidden;
+                }
+                .sidebar-inner {
+                    padding: {
+                        top: 80px;
+                        left: 12px;
+                        right: 12px;
+                    };
+                    .sidebar-menu {
+                        .sub-title {
+                            display: none;
+                        }
+                    }
+                    .mat-accordion {
+                        .mat-expansion-panel {
+                            margin-bottom: 5px;
+                
+                            .mat-expansion-panel-header {
+                                padding: 0;
+                                width: 36px;
+                                height: 36px;
+    
+                                i {
+                                    left: 0;
+                                    right: 0;
+                                    text-align: center;
+                                }
+                                .title {
+                                    display: none;
+                                }
+                                .mat-expansion-indicator {
+                                    display: none;
+                                }
+                                .daxa-badge {
+                                    display: none;
+                                }
+                            }
+                            .mat-expansion-panel-content {
+                                display: none;
+                            }
+                        }
+                        .sidebar-menu-link {
+                            padding: 0;
+                            width: 36px;
+                            height: 36px;
+                            margin-bottom: 5px;
+    
+                            i {
+                                left: 0;
+                                right: 0;
+                                text-align: center;
+                            }
+                            .title {
+                                display: none;
+                            }
+                        }
+                    }
+                }
+                &:hover {
+                    width: 260px;
+    
+                    .logo {
+                        padding: {
+                            left: 25px;
+                            right: 25px;
+                        };
+                        a {
+                            span {
+                                display: inline-block;
+                            }
+                        }
+                    }
+                    .burger-menu {
+                        opacity: 1;
+                        visibility: visible;
+                    }
+                    .sidebar-inner {
+                        padding: {
+                            top: 100px;
+                            left: 25px;
+                            right: 25px;
+                        };
+                        .sidebar-menu {
+                            .sub-title {
+                                display: block;
+                            }
+                        }
+                        .mat-accordion {
+                            .mat-expansion-panel {
+                                margin-bottom: 27px;
+                    
+                                .mat-expansion-panel-header {
+                                    width: auto;
+                                    height: auto;
+                                    padding: {
+                                        right: 43px;
+                                        left: 24px;
+                                    };
+                                    i {
+                                        right: auto;
+                                    }
+                                    .title {
+                                        display: block;
+                                    }
+                                    .mat-expansion-indicator {
+                                        display: inline-block;
+                                    }
+                                    .daxa-badge {
+                                        display: inline-block;
+                                    }
+                                }
+                                .mat-expansion-panel-content {
+                                    display: block;
+                                }
+                            }
+                            .sidebar-menu-link {
+                                width: auto;
+                                height: auto;
+                                margin-bottom: 27px;
+                                padding: {
+                                    right: 43px;
+                                    left: 24px;
+                                };
+                                i {
+                                    right: auto;
+                                }
+                                .title {
+                                    display: block;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            &.rtl-enabled {
+                &.active, &.hide-sidebar {
+                    .sidebar-inner {
+                        .sidebar-menu {
+                            .mat-accordion {
+                                .mat-expansion-panel {
+                                    .mat-expansion-panel-header {
+                                        padding: 0;
+
+                                        i {
+                                            left: 0;
+                                        }
+                                    }
+                                }
+                                .sidebar-menu-link {
+                                    padding: 0;
+
+                                    i {
+                                        left: 0;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    &:hover {
+                        .sidebar-inner {
+                            .sidebar-menu {
+                                .mat-accordion {
+                                    .mat-expansion-panel {
+                                        .mat-expansion-panel-header {
+                                            padding: {
+                                                right: 24px;
+                                                left: 43px;
+                                            };
+                                            i {
+                                                left: auto;
+                                                right: 0;
+                                            }
+                                        }
+                                    }
+                                    .sidebar-menu-link {
+                                        padding: {
+                                            left: 43px;
+                                            right: 24px;
+                                        };
+                                        i {
+                                            left: auto;
+                                            right: 0;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 1200px to Max width 1399px */
+@media only screen and (min-width: 1200px) and (max-width: 1399px) {
+
+    ::ng-deep {
+        .sidebar-area {
+            width: 240px;
+
+            &.active, &.hide-sidebar {
+                width: 60px;
+    
+                &:hover {
+                    width: 240px;
+                }
+            }
+        }
+    }
+
+}
+
+/* Min width 1600px */
+@media only screen and (min-width: 1600px) {}

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -1,31 +1,45 @@
 import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
-import { NgClass } from '@angular/common';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
 import { NgScrollbarModule } from 'ngx-scrollbar';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
+import { ToggleService } from './toggle.service';
+import { NgClass } from '@angular/common';
 import {CustomizerSettingsService} from "../../services/customizer-settings/customizer-settings.service";
 
 @Component({
-    selector: 'app-customizer-settings',
+    selector: 'app-sidebar',
     standalone: true,
-    imports: [RouterLink, NgClass, MatDividerModule, MatIconModule, MatButtonModule, NgScrollbarModule],
-    templateUrl: './customizer-settings.component.html',
-    styleUrl: './customizer-settings.component.scss'
+    imports: [NgScrollbarModule, MatExpansionModule, RouterLinkActive, RouterModule, RouterLink, NgClass],
+    templateUrl: './sidebar.component.html',
+    styleUrl: './sidebar.component.scss'
 })
-export class CustomizerSettingsComponent {
+export class SidebarComponent {
+
+    // isSidebarToggled
+    isSidebarToggled = false;
 
     // isToggled
     isToggled = false;
 
     constructor(
+        private toggleService: ToggleService,
         public themeService: CustomizerSettingsService
     ) {
+        this.toggleService.isSidebarToggled$.subscribe(isSidebarToggled => {
+            this.isSidebarToggled = isSidebarToggled;
+        });
         this.themeService.isToggled$.subscribe(isToggled => {
             this.isToggled = isToggled;
         });
     }
+
+    // Burger Menu Toggle
+    toggle() {
+        this.toggleService.toggle();
+    }
+
+    // Mat Expansion
+    panelOpenState = false;
 
     // Dark Mode
     toggleTheme() {
@@ -57,19 +71,9 @@ export class CustomizerSettingsComponent {
         this.themeService.toggleCardBorderTheme();
     }
 
-    // Card Border Radius
-    toggleCardBorderRadiusTheme() {
-        this.themeService.toggleCardBorderRadiusTheme();
-    }
-
     // RTL Mode
     toggleRTLEnabledTheme() {
         this.themeService.toggleRTLEnabledTheme();
-    }
-
-    // Settings Button Toggle
-    toggle() {
-        this.themeService.toggle();
     }
 
 }

--- a/src/app/shared/components/sidebar/toggle.service.spec.ts
+++ b/src/app/shared/components/sidebar/toggle.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ToggleService } from './toggle.service';
+
+describe('ToggleService', () => {
+    let service: ToggleService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        service = TestBed.inject(ToggleService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+});

--- a/src/app/shared/components/sidebar/toggle.service.ts
+++ b/src/app/shared/components/sidebar/toggle.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ToggleService {
+
+    private isSidebarToggled = new BehaviorSubject<boolean>(false);
+    get isSidebarToggled$() {
+        return this.isSidebarToggled.asObservable();
+    }
+    toggle() {
+        this.isSidebarToggled.next(!this.isSidebarToggled.value);
+    }
+
+}

--- a/src/app/shared/services/customizer-settings/customizer-settings.service.ts
+++ b/src/app/shared/services/customizer-settings/customizer-settings.service.ts
@@ -1,140 +1,102 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
-    providedIn: 'root'
+  providedIn: 'root'
 })
 export class CustomizerSettingsService {
-    
-    // Dark Mode
-    private isDarkTheme: boolean;
+  private isBrowser: boolean;
 
-    // Sidebar Dark Mode
-    private isSidebarDarkTheme: boolean;
+  private isDarkTheme = false;
+  private isSidebarDarkTheme = false;
+  private isRightSidebarTheme = false;
+  private isHideSidebarTheme = false;
+  private isHeaderDarkTheme = false;
+  private isCardBorderTheme = false;
+  private isCardBorderRadiusTheme = false;
+  private isRTLEnabledTheme = false;
 
-    // Right Sidebar
-    private isRightSidebarTheme: boolean;
+  constructor(@Inject(PLATFORM_ID) platformId: Object) {
+    this.isBrowser = isPlatformBrowser(platformId);
 
-    // Hide Sidebar
-    private isHideSidebarTheme: boolean;
-
-    // Header Dark Mode
-    private isHeaderDarkTheme: boolean;
-
-    // Card Border
-    private isCardBorderTheme: boolean;
-
-    // Card Border Radius
-    private isCardBorderRadiusTheme: boolean;
-
-    // RTL Mode
-    private isRTLEnabledTheme: boolean;
-
-    constructor() {
-        // Dark Mode
-        this.isDarkTheme = JSON.parse(localStorage.getItem('isDarkTheme')!);
-
-        // Sidebar Dark Mode
-        this.isSidebarDarkTheme = JSON.parse(localStorage.getItem('isSidebarDarkTheme')!);
-
-        // Right Sidebar
-        this.isRightSidebarTheme = JSON.parse(localStorage.getItem('isRightSidebarTheme')!);
-
-        // Hide Sidebar
-        this.isHideSidebarTheme = JSON.parse(localStorage.getItem('isHideSidebarTheme')!);
-
-        // Header Dark
-        this.isHeaderDarkTheme = JSON.parse(localStorage.getItem('isHeaderDarkTheme')!);
-
-        // Card Border
-        this.isCardBorderTheme = JSON.parse(localStorage.getItem('isCardBorderTheme')!);
-
-        // Card Border Radius
-        this.isCardBorderRadiusTheme = JSON.parse(localStorage.getItem('isCardBorderRadiusTheme')!);
-
-        // RTL Mode
-        this.isRTLEnabledTheme = JSON.parse(localStorage.getItem('isRTLEnabledTheme')!);
+    if (this.isBrowser) {
+      this.isDarkTheme = this.getBool('isDarkTheme');
+      this.isSidebarDarkTheme = this.getBool('isSidebarDarkTheme');
+      this.isRightSidebarTheme = this.getBool('isRightSidebarTheme');
+      this.isHideSidebarTheme = this.getBool('isHideSidebarTheme');
+      this.isHeaderDarkTheme = this.getBool('isHeaderDarkTheme');
+      this.isCardBorderTheme = this.getBool('isCardBorderTheme');
+      this.isCardBorderRadiusTheme = this.getBool('isCardBorderRadiusTheme');
+      this.isRTLEnabledTheme = this.getBool('isRTLEnabledTheme');
     }
+  }
 
-    // Dark Mode
-    toggleTheme() {
-        this.isDarkTheme = !this.isDarkTheme;
-        localStorage.setItem('isDarkTheme', JSON.stringify(this.isDarkTheme));
-    }
-    isDark() {
-        return this.isDarkTheme;
-    }
+  private getBool(key: string): boolean {
+    if (!this.isBrowser) return false;
+    const value = localStorage.getItem(key);
+    return value ? JSON.parse(value) : false;
+  }
 
-    // Sidebar Dark
-    toggleSidebarTheme() {
-        this.isSidebarDarkTheme = !this.isSidebarDarkTheme;
-        localStorage.setItem('isSidebarDarkTheme', JSON.stringify(this.isSidebarDarkTheme));
+  private setBool(key: string, value: boolean): void {
+    if (this.isBrowser) {
+      localStorage.setItem(key, JSON.stringify(value));
     }
-    isSidebarDark() {
-        return this.isSidebarDarkTheme;
-    }
+  }
 
-    // Right Sidebar
-    toggleRightSidebarTheme() {
-        this.isRightSidebarTheme = !this.isRightSidebarTheme;
-        localStorage.setItem('isRightSidebarTheme', JSON.stringify(this.isRightSidebarTheme));
-    }
-    isRightSidebar() {
-        return this.isRightSidebarTheme;
-    }
+  toggleTheme() {
+    this.isDarkTheme = !this.isDarkTheme;
+    this.setBool('isDarkTheme', this.isDarkTheme);
+  }
+  isDark() { return this.isDarkTheme; }
 
-    // Hide Sidebar
-    toggleHideSidebarTheme() {
-        this.isHideSidebarTheme = !this.isHideSidebarTheme;
-        localStorage.setItem('isHideSidebarTheme', JSON.stringify(this.isHideSidebarTheme));
-    }
-    isHideSidebar() {
-        return this.isHideSidebarTheme;
-    }
+  toggleSidebarTheme() {
+    this.isSidebarDarkTheme = !this.isSidebarDarkTheme;
+    this.setBool('isSidebarDarkTheme', this.isSidebarDarkTheme);
+  }
+  isSidebarDark() { return this.isSidebarDarkTheme; }
 
-    // Header Dark Mode
-    toggleHeaderTheme() {
-        this.isHeaderDarkTheme = !this.isHeaderDarkTheme;
-        localStorage.setItem('isHeaderDarkTheme', JSON.stringify(this.isHeaderDarkTheme));
-    }
-    isHeaderDark() {
-        return this.isHeaderDarkTheme;
-    }
+  toggleRightSidebarTheme() {
+    this.isRightSidebarTheme = !this.isRightSidebarTheme;
+    this.setBool('isRightSidebarTheme', this.isRightSidebarTheme);
+  }
+  isRightSidebar() { return this.isRightSidebarTheme; }
 
-    // Card Border
-    toggleCardBorderTheme() {
-        this.isCardBorderTheme = !this.isCardBorderTheme;
-        localStorage.setItem('isCardBorderTheme', JSON.stringify(this.isCardBorderTheme));
-    }
-    isCardBorder() {
-        return this.isCardBorderTheme;
-    }
+  toggleHideSidebarTheme() {
+    this.isHideSidebarTheme = !this.isHideSidebarTheme;
+    this.setBool('isHideSidebarTheme', this.isHideSidebarTheme);
+  }
+  isHideSidebar() { return this.isHideSidebarTheme; }
 
-    // Card Border Radius
-    toggleCardBorderRadiusTheme() {
-        this.isCardBorderRadiusTheme = !this.isCardBorderRadiusTheme;
-        localStorage.setItem('isCardBorderRadiusTheme', JSON.stringify(this.isCardBorderRadiusTheme));
-    }
-    isCardBorderRadius() {
-        return this.isCardBorderRadiusTheme;
-    }
+  toggleHeaderTheme() {
+    this.isHeaderDarkTheme = !this.isHeaderDarkTheme;
+    this.setBool('isHeaderDarkTheme', this.isHeaderDarkTheme);
+  }
+  isHeaderDark() { return this.isHeaderDarkTheme; }
 
-    // RTL Mode
-    toggleRTLEnabledTheme() {
-        this.isRTLEnabledTheme = !this.isRTLEnabledTheme;
-        localStorage.setItem('isRTLEnabledTheme', JSON.stringify(this.isRTLEnabledTheme));
-    }
-    isRTLEnabled() {
-        return this.isRTLEnabledTheme;
-    }
+  toggleCardBorderTheme() {
+    this.isCardBorderTheme = !this.isCardBorderTheme;
+    this.setBool('isCardBorderTheme', this.isCardBorderTheme);
+  }
+  isCardBorder() { return this.isCardBorderTheme; }
 
-    // isToggled
-    private isToggled = new BehaviorSubject<boolean>(false);
-    get isToggled$() {
-        return this.isToggled.asObservable();
-    }
-    toggle() {
-        this.isToggled.next(!this.isToggled.value);
-    }
-    
+  toggleCardBorderRadiusTheme() {
+    this.isCardBorderRadiusTheme = !this.isCardBorderRadiusTheme;
+    this.setBool('isCardBorderRadiusTheme', this.isCardBorderRadiusTheme);
+  }
+  isCardBorderRadius() { return this.isCardBorderRadiusTheme; }
+
+  toggleRTLEnabledTheme() {
+    this.isRTLEnabledTheme = !this.isRTLEnabledTheme;
+    this.setBool('isRTLEnabledTheme', this.isRTLEnabledTheme);
+  }
+  isRTLEnabled() { return this.isRTLEnabledTheme; }
+
+  private isToggled = new BehaviorSubject<boolean>(false);
+  get isToggled$() {
+    return this.isToggled.asObservable();
+  }
+  toggle() {
+    this.isToggled.next(!this.isToggled.value);
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Llantatech</title>
+    <title>RutaKids</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
- Created conditional logic in AppComponent to hide layout components on authentication routes
- Ensured sidebar, header, and footer only render after login
- Moved layout components (sidebar, header, footer) to shared module for reuse
- Set up route detection using startsWith('/authentication') for cleaner logic